### PR TITLE
Create Config and DatasetManager to load and store data generically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pyc
+config.yaml

--- a/DataManagementExample.ipynb
+++ b/DataManagementExample.ipynb
@@ -1,0 +1,157 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loading dataset from dataset_config:\n",
+      "DatasetConfig(\n",
+      "\traw_data_source_type=local\n",
+      "\traw_data_dir=C:\\TESS\\data\\lc\\Vetting\n",
+      "\treports_dir=C:\\TESS\\data\\reports\n",
+      "\timages_dir=C:\\TESS\\data\\images\n",
+      "\tlabels_sheet=https://docs.google.com/spreadsheets/d/17-ByYBQ1uPweKH2P_4MWGWsuTKkEKrNFS4uGBsm-bGI/edit?gid=0#gid=0\n",
+      "\tproperties_sheet=https://docs.google.com/spreadsheets/d/1hRVFAegDeTRTFq2ZV4H02On3Hvn4Xu4y3C8ayGk4Uzo/edit?gid=0#gid=0\n",
+      "\tdataset_split_sheet=https://docs.google.com/spreadsheets/d/1w_YvlGCQpdlPPC7JJgAUDANU2JU0cC9P-gwMeoYvMw8/edit?gid=0#gid=0\n",
+      ")\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\TESS\\pr\\astronet\\data_management\\google_sheets_reader.py:59: FutureWarning: Downcasting behavior in `replace` is deprecated and will be removed in a future version. To retain the old behavior, explicitly call `result.infer_objects(copy=False)`. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`\n",
+      "  df.replace([\"#N/A\", \"\", \"N/A\"], np.nan, inplace=True)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AstroDataReport:\n",
+      "  - # Successful Load: 2286\n",
+      "  - FITS Files Failed to Load: 7058\n",
+      "  - Labels Failed to Load: 0\n",
+      "  - Properties Failed to Load: 0\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Imports\n",
+    "from data_management.data_manager import data_manager"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      astro_id     tic_id                                          fits_path  \\\n",
+      "0           93  120689840  C:\\TESS\\data\\lc\\Vetting\\mk_hlsp_qlp_tess_ffi-s...   \n",
+      "1           99  122603474  C:\\TESS\\data\\lc\\Vetting\\mk_hlsp_qlp_tess_ffi-s...   \n",
+      "2          109  127722285  C:\\TESS\\data\\lc\\Vetting\\mk_hlsp_qlp_tess_ffi-s...   \n",
+      "3  12783612901  127836129  C:\\TESS\\data\\lc\\Vetting\\mk_hlsp_qlp_tess_ffi-s...   \n",
+      "4          142  139144054  C:\\TESS\\data\\lc\\Vetting\\mk_hlsp_qlp_tess_ffi-s...   \n",
+      "\n",
+      "                                        report_paths label  label_simplified  \\\n",
+      "0  ['C:\\\\TESS\\\\data\\\\reports\\\\120689840.page1.png...    eb  Eclipsing Binary   \n",
+      "1  ['C:\\\\TESS\\\\data\\\\reports\\\\122603474.page1.png...    eb  Eclipsing Binary   \n",
+      "2  ['C:\\\\TESS\\\\data\\\\reports\\\\127722285.page1.png...    pt            Planet   \n",
+      "3  ['C:\\\\TESS\\\\data\\\\reports\\\\127836129.page1.png...    eb  Eclipsing Binary   \n",
+      "4  ['C:\\\\TESS\\\\data\\\\reports\\\\139144054.page1.png...  <NA>              <NA>   \n",
+      "\n",
+      "        split distinct                                      astronet_note  \\\n",
+      "0       train        2                                               <NA>   \n",
+      "1       train        2                                               <NA>   \n",
+      "2  validation        3  very likely \"et\"; no radius, deep transit; lik...   \n",
+      "3       train        1                                               <NA>   \n",
+      "4       train        3  re-visit after detrending. check odd-even & de...   \n",
+      "\n",
+      "   smass     srad     tmag  planetno         epoc       per        depth  \\\n",
+      "0    NaN      NaN      NaN       NaN          NaN       NaN          NaN   \n",
+      "1    NaN      NaN      NaN       NaN          NaN       NaN          NaN   \n",
+      "2    NaN      NaN      NaN       NaN          NaN       NaN          NaN   \n",
+      "3  1.248  1.14191  9.29048       1.0  1818.588392  3.450708  2501.320218   \n",
+      "4    NaN      NaN      NaN       NaN          NaN       NaN          NaN   \n",
+      "\n",
+      "        dur  srad_est  \n",
+      "0       NaN       NaN  \n",
+      "1       NaN       NaN  \n",
+      "2       NaN       NaN  \n",
+      "3  0.212706       NaN  \n",
+      "4       NaN       NaN  \n"
+     ]
+    }
+   ],
+   "source": [
+    "# show properties in the data frame\n",
+    "df = data_manager.get_data_frame()\n",
+    "print(df.head())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Showing labels for TIC ID: 19686666\n",
+      "      tic_id label  label_simplified\n",
+      "98  19686666    eu  Eclipsing Binary\n",
+      "Raw data path: C:\\TESS\\data\\lc\\Vetting\\mk_hlsp_qlp_tess_ffi-s0007-0000000019686666_tess_v01_llc.fits\n",
+      "Report path: ['C:\\\\TESS\\\\data\\\\reports\\\\19686666.page1.png', 'C:\\\\TESS\\\\data\\\\reports\\\\19686666.page2.png', 'C:\\\\TESS\\\\data\\\\reports\\\\19686666.page3.png']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Show labels for a specific TIC ID\n",
+    "# grab a TIC id at random from the df where the label is not NaN\n",
+    "tic_id = df.loc[df['label'].notna(), 'tic_id'].sample(1).values[0]\n",
+    "print(f\"Showing labels for TIC ID: {tic_id}\")\n",
+    "# show simplified label and label\n",
+    "df_labels = df.loc[df['tic_id'] == tic_id, ['tic_id', 'label', 'label_simplified']]\n",
+    "print(df_labels)\n",
+    "# print the raw data path and report path for the TIC ID\n",
+    "df_raw_path = df.loc[df['tic_id'] == tic_id, 'fits_path'].values[0]\n",
+    "df_report_path = df.loc[df['tic_id'] == tic_id, 'report_paths'].values[0]\n",
+    "print(f\"Raw data path: {df_raw_path}\")\n",
+    "print(f\"Report path: {df_report_path}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,6 @@
+dataset:
+  raw_data_source_type: "local"
+  raw_data_dir: "<path>" # fill your path here (local or PDO)
+  labels_sheet: '<url>' # Google sheets URL - sheet must be public. Should contain (Astro ID, TIC ID, Final)
+  properties_sheet: '<url>' # Should contain (TIC ID, Other Properties)
+  dataset_split_sheet: '<url>' # Should contain (TIC ID, Split)

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 dataset:
   raw_data_source_type: "local"
-  raw_data_dir: "C:\\TESS\\data\\lc\\Vetting"
-  labels_sheet: 'https://docs.google.com/spreadsheets/d/17-ByYBQ1uPweKH2P_4MWGWsuTKkEKrNFS4uGBsm-bGI/edit?gid=0#gid=0'
-  properties_sheet: 'https://docs.google.com/spreadsheets/d/1esYObG5TU2MQYOzvMklvYcwsYdTpWy5-BHpDaxgLDj8/edit?gid=789406476#gid=789406476'
-  dataset_split_sheet: 'https://docs.google.com/spreadsheets/d/1w_YvlGCQpdlPPC7JJgAUDANU2JU0cC9P-gwMeoYvMw8/edit?gid=0#gid=0'
+  raw_data_dir: "<path/to/dir>"
+  labels_sheet: '<url>' # should contain (Astro ID, TIC ID, Final)
+  properties_sheet: '<url>' # should contain (TIC ID, properties)
+  dataset_split_sheet: '<url>' # should contain (TIC ID, Split)

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 dataset:
   raw_data_source_type: "local"
-  raw_data_dir: "<path>" # fill your path here (local or PDO)
-  labels_sheet: '<url>' # Google sheets URL - sheet must be public. Should contain (Astro ID, TIC ID, Final)
-  properties_sheet: '<url>' # Should contain (TIC ID, Other Properties)
-  dataset_split_sheet: '<url>' # Should contain (TIC ID, Split)
+  raw_data_dir: "C:\\TESS\\data\\lc\\Vetting"
+  labels_sheet: 'https://docs.google.com/spreadsheets/d/17-ByYBQ1uPweKH2P_4MWGWsuTKkEKrNFS4uGBsm-bGI/edit?gid=0#gid=0'
+  properties_sheet: 'https://docs.google.com/spreadsheets/d/1esYObG5TU2MQYOzvMklvYcwsYdTpWy5-BHpDaxgLDj8/edit?gid=789406476#gid=789406476'
+  dataset_split_sheet: 'https://docs.google.com/spreadsheets/d/1w_YvlGCQpdlPPC7JJgAUDANU2JU0cC9P-gwMeoYvMw8/edit?gid=0#gid=0'

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,10 @@
 dataset:
   raw_data_source_type: "local"
-  raw_data_dir: "<path/to/dir>"
-  labels_sheet: '<url>' # should contain (Astro ID, TIC ID, Final)
-  properties_sheet: '<url>' # should contain (TIC ID, properties)
-  dataset_split_sheet: '<url>' # should contain (TIC ID, Split)
+  raw_data_dir: "C:\\TESS\\data\\lc\\Vetting"
+  images_dir: "C:\\TESS\\data\\images"
+  reports_dir: "C:\\TESS\\data\\reports"
+  labels_sheet: 'https://docs.google.com/spreadsheets/d/17-ByYBQ1uPweKH2P_4MWGWsuTKkEKrNFS4uGBsm-bGI/edit?gid=0#gid=0'
+  #properties_sheet: 'https://docs.google.com/spreadsheets/d/1zWFZ0GQ09aBfoT-G1GzgtMDlqiJpI2KXrnTK-7-Lp1E/edit?gid=680688174#gid=680688174'
+  properties_sheet: 'https://docs.google.com/spreadsheets/d/1hRVFAegDeTRTFq2ZV4H02On3Hvn4Xu4y3C8ayGk4Uzo/edit?gid=0#gid=0'
+  dataset_split_sheet: 'https://docs.google.com/spreadsheets/d/1w_YvlGCQpdlPPC7JJgAUDANU2JU0cC9P-gwMeoYvMw8/edit?gid=0#gid=0'
+  eval_sheet: 'https://docs.google.com/spreadsheets/d/1x7MqQK6mEedUrsKO8Z7T0x_APT-6S1ik6UMvAYx4ZFg/edit?gid=302748837#gid=302748837'

--- a/config_parser.py
+++ b/config_parser.py
@@ -69,6 +69,14 @@ class DatasetConfig:
             dataset_split_sheet=dataset.get(Constants.DATASET_SPLIT_SHEET),
         )
 
+    def __str__(self) -> str:
+        return "DatasetConfig(\n\t" \
+            f"raw_data_source_type={self.raw_data_source_type}\n\t" \
+            f"raw_data_dir={self.raw_data_dir}\n\t" \
+            f"labels_sheet={self.labels_sheet}\n\t" \
+            f"properties_sheet={self.properties_sheet}\n\t" \
+            f"dataset_split_sheet={self.dataset_split_sheet}\n)"
+
 if __name__ == "__main__":
     dataset_config = DatasetConfig.from_yaml("config.yaml")
     print(f'Loaded dataset config: {dataset_config}')

--- a/config_parser.py
+++ b/config_parser.py
@@ -1,0 +1,74 @@
+import yaml
+from dataclasses import dataclass
+from pathlib import Path
+import os
+
+"""
+HOW TO USE THIS API
+
+The config_parser is meant to be used to create a DatasetConfig which is an
+input to a DataManager.
+
+By filling out config.yaml, you can maintain a single dataset object to use in
+every notebook rather than filling out individually all of the sheets you need.
+Sheets can also be loaded dynamically live from Google to keep the latest
+source of truth.
+
+"""
+
+class Constants:
+    """String constants used throughout the project."""
+
+    CONFIG_FILE: str = "config.yaml"
+
+    # Dataset keys
+    DATASET: str = "dataset"
+    RAW_DATA_SOURCE_TYPE: str = "raw_data_source_type"
+    RAW_DATA_DIR: str = "raw_data_dir"
+
+    # Source Types
+    LOCAL: str = "local"
+    REMOTE: str = "remote"
+
+    # Sheets
+    LABELS_SHEET: str = "labels_sheet"
+    PROPERTIES_SHEET: str = "properties_sheet"
+    DATASET_SPLIT_SHEET: str = "dataset_split_sheet"
+
+@dataclass
+class DatasetConfig:
+    """Dataclass to store dataset configuration."""
+    raw_data_source_type: str
+    raw_data_dir: Path
+    labels_sheet: str
+    properties_sheet: str
+    dataset_split_sheet: str
+
+    @staticmethod
+    def from_yaml(config_path: str = Constants.CONFIG_FILE) -> "DatasetConfig":
+        """Reads YAML configuration and returns a DatasetConfig instance."""
+
+        config_file = Path(config_path)
+
+        if not config_file.exists():
+            raise FileNotFoundError(f"Config file not found: {config_file}")
+
+        with open(config_file, "r") as file:
+            config = yaml.safe_load(file)
+
+        if Constants.DATASET not in config:
+            raise ValueError(f"Invalid config format: Missing '{Constants.DATASET}' section.")
+
+        dataset = config[Constants.DATASET]
+
+        return DatasetConfig(
+            raw_data_source_type=dataset.get(Constants.RAW_DATA_SOURCE_TYPE),
+            raw_data_dir=Path(dataset.get(Constants.RAW_DATA_DIR)),
+            labels_sheet=dataset.get(Constants.LABELS_SHEET),
+            properties_sheet=dataset.get(Constants.PROPERTIES_SHEET),
+            dataset_split_sheet=dataset.get(Constants.DATASET_SPLIT_SHEET),
+        )
+
+if __name__ == "__main__":
+    dataset_config = DatasetConfig.from_yaml("config.yaml")
+    print(f'Loaded dataset config: {dataset_config}')

--- a/config_parser.py
+++ b/config_parser.py
@@ -1,7 +1,6 @@
+from __future__ import annotations
 import yaml
-from dataclasses import dataclass
 from pathlib import Path
-import os
 
 """
 HOW TO USE THIS API
@@ -15,6 +14,12 @@ Sheets can also be loaded dynamically live from Google to keep the latest
 source of truth.
 
 """
+
+import yaml
+from pathlib import Path
+from pydantic import BaseModel
+from typing import Optional
+
 
 class Constants:
     """String constants used throughout the project."""
@@ -35,19 +40,18 @@ class Constants:
     PROPERTIES_SHEET: str = "properties_sheet"
     DATASET_SPLIT_SHEET: str = "dataset_split_sheet"
 
-@dataclass
-class DatasetConfig:
-    """Dataclass to store dataset configuration."""
+
+class DatasetConfig(BaseModel):
+    """Pydantic model to store dataset configuration."""
     raw_data_source_type: str
     raw_data_dir: Path
     labels_sheet: str
     properties_sheet: str
     dataset_split_sheet: str
 
-    @staticmethod
-    def from_yaml(config_path: str = Constants.CONFIG_FILE) -> "DatasetConfig":
+    @classmethod
+    def from_yaml(cls, config_path: str = Constants.CONFIG_FILE) -> DatasetConfig:
         """Reads YAML configuration and returns a DatasetConfig instance."""
-
         config_file = Path(config_path)
 
         if not config_file.exists():
@@ -60,14 +64,7 @@ class DatasetConfig:
             raise ValueError(f"Invalid config format: Missing '{Constants.DATASET}' section.")
 
         dataset = config[Constants.DATASET]
-
-        return DatasetConfig(
-            raw_data_source_type=dataset.get(Constants.RAW_DATA_SOURCE_TYPE),
-            raw_data_dir=Path(dataset.get(Constants.RAW_DATA_DIR)),
-            labels_sheet=dataset.get(Constants.LABELS_SHEET),
-            properties_sheet=dataset.get(Constants.PROPERTIES_SHEET),
-            dataset_split_sheet=dataset.get(Constants.DATASET_SPLIT_SHEET),
-        )
+        return cls(**dataset)
 
     def __str__(self) -> str:
         return "DatasetConfig(\n\t" \
@@ -76,6 +73,7 @@ class DatasetConfig:
             f"labels_sheet={self.labels_sheet}\n\t" \
             f"properties_sheet={self.properties_sheet}\n\t" \
             f"dataset_split_sheet={self.dataset_split_sheet}\n)"
+
 
 if __name__ == "__main__":
     dataset_config = DatasetConfig.from_yaml("config.yaml")

--- a/config_parser.py
+++ b/config_parser.py
@@ -18,7 +18,6 @@ source of truth.
 import yaml
 from pathlib import Path
 from pydantic import BaseModel
-from typing import Optional
 
 
 class Constants:
@@ -30,6 +29,8 @@ class Constants:
     DATASET: str = "dataset"
     RAW_DATA_SOURCE_TYPE: str = "raw_data_source_type"
     RAW_DATA_DIR: str = "raw_data_dir"
+    IMAGES_DIR: str = "images_dir"
+    REPORTS_DIR: str = "reports_dir"
 
     # Source Types
     LOCAL: str = "local"
@@ -45,6 +46,8 @@ class DatasetConfig(BaseModel):
     """Pydantic model to store dataset configuration."""
     raw_data_source_type: str
     raw_data_dir: Path
+    images_dir: Path
+    reports_dir: Path
     labels_sheet: str
     properties_sheet: str
     dataset_split_sheet: str
@@ -70,6 +73,8 @@ class DatasetConfig(BaseModel):
         return "DatasetConfig(\n\t" \
             f"raw_data_source_type={self.raw_data_source_type}\n\t" \
             f"raw_data_dir={self.raw_data_dir}\n\t" \
+            f"reports_dir={self.reports_dir}\n\t" \
+            f"images_dir={self.images_dir}\n\t" \
             f"labels_sheet={self.labels_sheet}\n\t" \
             f"properties_sheet={self.properties_sheet}\n\t" \
             f"dataset_split_sheet={self.dataset_split_sheet}\n)"

--- a/data_management/astro_data.py
+++ b/data_management/astro_data.py
@@ -1,0 +1,92 @@
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+from light_curve_util import tess_io
+from light_curve_util import keplersplinev2
+from light_curve_util import median_filter2
+from light_curve_util import util
+import numpy as np
+
+@dataclass
+class AstroData:
+    astro_id: int
+    tic_id: int
+    fits_path: str
+    report_path: Optional[str]
+    properties: Dict[str, Any]
+    label: Optional[str] = None
+
+    @property
+    def id(self) -> Optional[int]:
+        return self.properties.get('id')
+
+    @property
+    def version_id(self) -> Optional[int]:
+        return self.properties.get('version_id')
+
+    @property
+    def ra(self) -> Optional[float]:
+        return self.properties.get('ra')
+
+    @property
+    def dec(self) -> Optional[float]:
+        return self.properties.get('dec')
+
+    @property
+    def tmag(self) -> Optional[float]:
+        return self.properties.get('tmag')
+
+    @property
+    def epoc(self) -> Optional[float]:
+        return self.properties.get('epoc')
+
+    @property
+    def period(self) -> Optional[float]:
+        return self.properties.get('period')
+
+    @property
+    def duration(self) -> Optional[float]:
+        return self.properties.get('duration')
+
+    @property
+    def transit_depth(self) -> Optional[float]:
+        return self.properties.get('transit_depth')
+
+    @property
+    def sectors(self) -> Optional[Any]:
+        return self.properties.get('sectors')
+
+    @property
+    def star_rad(self) -> Optional[float]:
+        return self.properties.get('star_rad')
+
+    @property
+    def star_mass(self) -> Optional[float]:
+        return self.properties.get('star_mass')
+
+    @property
+    def teff(self) -> Optional[float]:
+        return self.properties.get('teff')
+
+    @property
+    def logg(self) -> Optional[float]:
+        return self.properties.get('logg')
+
+    @property
+    def sn(self) -> Optional[float]:
+        return self.properties.get('sn')
+
+    @property
+    def qingress(self) -> Optional[float]:
+        return self.properties.get('qingress')
+
+    @property
+    def star_rad_est(self) -> Optional[float]:
+        return self.properties.get('star_rad_est')
+
+    @property
+    def filename(self) -> Optional[str]:
+        return self.properties.get('filename')
+
+    @property
+    def comment(self) -> Optional[str]:
+        return self.properties.get('comment')

--- a/data_management/astro_data.py
+++ b/data_management/astro_data.py
@@ -1,13 +1,36 @@
+from __future__ import annotations
 from dataclasses import dataclass
+from enum import Enum
+
+class Split(Enum):
+    TRAIN = 'train'
+    VALIDATION = 'validation'
+    TEST = 'test'
+    UNALLOCATED = 'unallocated'
+
+    @classmethod
+    def from_str(cls, s: str) -> Split:
+        s = str(s)
+        if s.lower() == cls.TRAIN.value:
+            return cls.TRAIN
+        elif s.lower() == cls.VALIDATION.value or s.lower() == 'val':
+            return cls.VALIDATION
+        elif s.lower() == cls.TEST:
+            return cls.TEST
+        else:
+            return cls.UNALLOCATED
 
 @dataclass
 class AstroData:
     astro_id: int
     tic_id: int
     fits_path: str
-    report_path: str | None
+    report_paths: list[str]
+    images_path: str | None
     properties: dict[str, object]
+    split: Split
     label: str | None = None
+    label_simplified: str | None = None
 
     @property
     def id(self) -> int | None:

--- a/data_management/astro_data.py
+++ b/data_management/astro_data.py
@@ -1,92 +1,86 @@
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple
-from light_curve_util import tess_io
-from light_curve_util import keplersplinev2
-from light_curve_util import median_filter2
-from light_curve_util import util
-import numpy as np
 
 @dataclass
 class AstroData:
     astro_id: int
     tic_id: int
     fits_path: str
-    report_path: Optional[str]
-    properties: Dict[str, Any]
-    label: Optional[str] = None
+    report_path: str | None
+    properties: dict[str, object]
+    label: str | None = None
 
     @property
-    def id(self) -> Optional[int]:
+    def id(self) -> int | None:
         return self.properties.get('id')
 
     @property
-    def version_id(self) -> Optional[int]:
+    def version_id(self) -> int | None:
         return self.properties.get('version_id')
 
     @property
-    def ra(self) -> Optional[float]:
+    def ra(self) -> float | None:
         return self.properties.get('ra')
 
     @property
-    def dec(self) -> Optional[float]:
+    def dec(self) -> float | None:
         return self.properties.get('dec')
 
     @property
-    def tmag(self) -> Optional[float]:
+    def tmag(self) -> float | None:
         return self.properties.get('tmag')
 
     @property
-    def epoc(self) -> Optional[float]:
+    def epoc(self) -> float | None:
         return self.properties.get('epoc')
 
     @property
-    def period(self) -> Optional[float]:
+    def period(self) -> float | None:
         return self.properties.get('period')
 
     @property
-    def duration(self) -> Optional[float]:
+    def duration(self) -> float | None:
         return self.properties.get('duration')
 
     @property
-    def transit_depth(self) -> Optional[float]:
+    def transit_depth(self) -> float | None:
         return self.properties.get('transit_depth')
 
     @property
-    def sectors(self) -> Optional[Any]:
+    def sectors(self) -> object | None:
         return self.properties.get('sectors')
 
     @property
-    def star_rad(self) -> Optional[float]:
+    def star_rad(self) -> float | None:
         return self.properties.get('star_rad')
 
     @property
-    def star_mass(self) -> Optional[float]:
+    def star_mass(self) -> float | None:
         return self.properties.get('star_mass')
 
     @property
-    def teff(self) -> Optional[float]:
+    def teff(self) -> float | None:
         return self.properties.get('teff')
 
     @property
-    def logg(self) -> Optional[float]:
+    def logg(self) -> float | None:
         return self.properties.get('logg')
 
     @property
-    def sn(self) -> Optional[float]:
+    def sn(self) -> float | None:
         return self.properties.get('sn')
 
     @property
-    def qingress(self) -> Optional[float]:
+    def qingress(self) -> float | None:
         return self.properties.get('qingress')
 
     @property
-    def star_rad_est(self) -> Optional[float]:
+    def star_rad_est(self) -> float | None:
         return self.properties.get('star_rad_est')
 
     @property
-    def filename(self) -> Optional[str]:
+    def filename(self) -> str | None:
         return self.properties.get('filename')
 
     @property
-    def comment(self) -> Optional[str]:
+    def comment(self) -> str | None:
         return self.properties.get('comment')

--- a/data_management/data_manager.py
+++ b/data_management/data_manager.py
@@ -129,11 +129,12 @@ class DataManager:
 
         # Read sheets
         labels_sheet = dataset_config.labels_sheet
-        self.labels_df = GoogleSheetsReader.from_url(labels_sheet)
+        sheets_reader = GoogleSheetsReader()
+        self.labels_df = sheets_reader.from_url(labels_sheet)
         properties_sheet = dataset_config.properties_sheet
-        self.properties_df = GoogleSheetsReader.from_url(properties_sheet)
+        self.properties_df = sheets_reader.from_url(properties_sheet)
         dataset_split_sheet = dataset_config.dataset_split_sheet
-        self.dataset_split_df = GoogleSheetsReader.from_url(dataset_split_sheet)
+        self.dataset_split_df = sheets_reader.from_url(dataset_split_sheet)
 
         # Init data
         (self.astro_data, report) = self._init_astro_data()

--- a/data_management/data_manager.py
+++ b/data_management/data_manager.py
@@ -1,0 +1,150 @@
+from pathlib import Path
+from config_parser import DatasetConfig
+import pandas as pd
+from typing import List, Tuple
+from dataclasses import dataclass
+from data_management.astro_data import AstroData
+from data_management.google_sheets_reader import GoogleSheetsReader
+from data_management.data_storage import DataStorage
+
+dataset_config = DatasetConfig.from_yaml()
+
+class AstroDataReportConstants:
+    NUM_SUCCESSFUL_LOADS = 'num_successful_loads'
+    NUM_FITS_FAILED_TO_LOAD = 'num_fits_failed_to_load'
+    NUM_LABELS_FAILED_TO_LOAD = 'num_labels_failed_to_load'
+    NUM_PROPERTIES_FAILED_TO_LOAD = 'num_properties_failed_to_load'
+
+class DataManagerConstants:
+    TIC_ID_COLUMN = "TIC ID"
+    SPLIT_COLUMN = "Split"
+    LABEL_COLUMN = "Final"
+    ASTRO_ID_COLUMN = "Astro ID"
+    DISTINCT_COLUMN = "Distinct"
+    ASTRONET_NOTE_COLUMN = "Astronet note"
+
+@dataclass
+class AstroDataReport:
+    num_successful_loads: int
+    num_fits_failed_to_load: int
+    num_labels_failed_to_load: int
+    num_properties_failed_to_load: int
+
+    def __str__(self):
+        return (
+            "AstroDataReport:\n"
+            f"  - # Successful Load: {self.num_successful_loads}\n"
+            f"  - FITS Files Failed to Load: {self.num_fits_failed_to_load}\n"
+            f"  - Labels Failed to Load: {self.num_labels_failed_to_load}\n"
+            f"  - Properties Failed to Load: {self.num_properties_failed_to_load}"
+        )
+
+def to_camel_case(s: str):
+    return s.lower().replace(' ', '_')
+
+class DataManager:
+    """
+    Links all data sources together into AstroData objects.
+
+    Utilizes the Google sheets + storage directory. Rows are loaded based on
+    the test/train/validation split sheet, so that no other data is loaded if it
+    is not needed.
+    """
+
+
+    def _init_astro_data(self) -> Tuple[List[AstroData], AstroDataReport]:
+        astro_data = []
+        astro_data_report = {
+            AstroDataReportConstants.NUM_SUCCESSFUL_LOADS: 0,
+            AstroDataReportConstants.NUM_FITS_FAILED_TO_LOAD: 0,
+            AstroDataReportConstants.NUM_LABELS_FAILED_TO_LOAD: 0,
+            AstroDataReportConstants.NUM_PROPERTIES_FAILED_TO_LOAD: 0
+        }
+
+        # Load data based on the test/train/validation sheet
+        for index, row in self.dataset_split_df.iterrows():
+            try:
+                tic_id = int(row[DataManagerConstants.TIC_ID_COLUMN])
+                split = row[DataManagerConstants.SPLIT_COLUMN]
+
+                labels_row = self.labels_df[self.labels_df[DataManagerConstants.TIC_ID_COLUMN] == tic_id]
+                labels_dict = labels_row.to_dict(orient='records')[0] if not labels_row.empty else {}
+                if not labels_dict:
+                    astro_data_report[AstroDataReportConstants.NUM_LABELS_FAILED_TO_LOAD] += 1
+                    continue
+
+                label = labels_dict[DataManagerConstants.LABEL_COLUMN]
+                astro_id = labels_dict[DataManagerConstants.ASTRO_ID_COLUMN]
+
+                properties_row = self.properties_df[self.properties_df[DataManagerConstants.TIC_ID_COLUMN] == tic_id]
+                properties_dict = (
+                    {to_camel_case(k): v for k, v in properties_row.to_dict(orient='records')[0].items()}
+                    if not properties_row.empty else {}
+                )
+
+                properties_dict.update(
+                    {
+                        'distinct': labels_dict.get(DataManagerConstants.DISTINCT_COLUMN),
+                        'astronet_note': labels_dict.get(DataManagerConstants.ASTRONET_NOTE_COLUMN)
+                    }
+                )
+
+                fits_path = self.data_storage.get_path(tic_id=tic_id)
+                if not fits_path:
+                    astro_data_report[AstroDataReportConstants.NUM_FITS_FAILED_TO_LOAD] += 1
+                    continue
+
+
+                astro_data.append(AstroData(
+                    astro_id=astro_id,
+                    tic_id=tic_id,
+                    fits_path=fits_path,
+                    report_path=None,
+                    properties=properties_dict,
+                    label=label,
+                ))
+                astro_data_report[AstroDataReportConstants.NUM_SUCCESSFUL_LOADS] += 1
+            except Exception as e:
+                print(f'Failed to load tic_id={tic_id} with exception ' + str(e) + ', skipping...')
+
+        report = AstroDataReport(
+            num_successful_loads=astro_data_report.get(AstroDataReportConstants.NUM_SUCCESSFUL_LOADS, 0),
+            num_fits_failed_to_load=astro_data_report.get(AstroDataReportConstants.NUM_FITS_FAILED_TO_LOAD, 0),
+            num_labels_failed_to_load=astro_data_report.get(AstroDataReportConstants.NUM_LABELS_FAILED_TO_LOAD, 0),
+            num_properties_failed_to_load=astro_data_report.get(AstroDataReportConstants.NUM_PROPERTIES_FAILED_TO_LOAD, 0)
+        )
+        return (astro_data, report)
+
+    def get_data_from_tic_id(self, tic_id: int) -> AstroData:
+            data = self.tic_id_to_data.get(tic_id)
+            if not data:
+                raise Exception(f"Data not found for tic id {tic_id}")
+            return data
+
+
+    def __init__(self):
+        print(f'Loading dataset from dataset_config:\n{dataset_config}\n')
+        self.data_dir = dataset_config.raw_data_dir
+        self.data_storage = DataStorage(data_dir=self.data_dir)
+
+        # Read sheets
+        labels_sheet = dataset_config.labels_sheet
+        self.labels_df = GoogleSheetsReader.from_url(labels_sheet)
+        properties_sheet = dataset_config.properties_sheet
+        self.properties_df = GoogleSheetsReader.from_url(properties_sheet)
+        dataset_split_sheet = dataset_config.dataset_split_sheet
+        self.dataset_split_df = GoogleSheetsReader.from_url(dataset_split_sheet)
+
+        # Init data
+        (self.astro_data, report) = self._init_astro_data()
+        self.tic_id_to_data = {}
+        for data in self.astro_data:
+            self.tic_id_to_data[data.tic_id] = data
+        print(str(report) + '\n')
+
+data_manager = DataManager() # singleton
+
+# Example usage:
+if __name__ == "__main__":
+    tic_id_example = 100100823
+    print(data_manager.tic_id_to_data[tic_id_example])

--- a/data_management/data_manager.py
+++ b/data_management/data_manager.py
@@ -1,7 +1,5 @@
 from pathlib import Path
 from config_parser import DatasetConfig
-import pandas as pd
-from typing import List, Tuple
 from dataclasses import dataclass
 from data_management.astro_data import AstroData
 from data_management.google_sheets_reader import GoogleSheetsReader
@@ -9,19 +7,20 @@ from data_management.data_storage import DataStorage
 
 dataset_config = DatasetConfig.from_yaml()
 
-class AstroDataReportConstants:
-    NUM_SUCCESSFUL_LOADS = 'num_successful_loads'
-    NUM_FITS_FAILED_TO_LOAD = 'num_fits_failed_to_load'
-    NUM_LABELS_FAILED_TO_LOAD = 'num_labels_failed_to_load'
-    NUM_PROPERTIES_FAILED_TO_LOAD = 'num_properties_failed_to_load'
+@dataclass
+class AstroDataReport:
+    num_successful_loads: int = 0
+    num_fits_failed_to_load: int = 0
+    num_labels_failed_to_load: int = 0
+    num_properties_failed_to_load: int = 0
 
 class DataManagerConstants:
     TIC_ID_COLUMN = "TIC ID"
-    SPLIT_COLUMN = "Split"
-    LABEL_COLUMN = "Final"
-    ASTRO_ID_COLUMN = "Astro ID"
-    DISTINCT_COLUMN = "Distinct"
-    ASTRONET_NOTE_COLUMN = "Astronet note"
+    SPLIT_COLUMN = "Split" # Comes from dataset split sheet
+    LABEL_COLUMN = "Final" # Comes from labels sheet
+    ASTRO_ID_COLUMN = "Astro ID" # Comes from all sheets (primary key)
+    DISTINCT_COLUMN = "Distinct" # Comes from labels sheet
+    ASTRONET_NOTE_COLUMN = "Astronet note" # Comes from labels sheet (human notes about the labels)
 
 @dataclass
 class AstroDataReport:
@@ -51,77 +50,6 @@ class DataManager:
     is not needed.
     """
 
-
-    def _init_astro_data(self) -> Tuple[List[AstroData], AstroDataReport]:
-        astro_data = []
-        astro_data_report = {
-            AstroDataReportConstants.NUM_SUCCESSFUL_LOADS: 0,
-            AstroDataReportConstants.NUM_FITS_FAILED_TO_LOAD: 0,
-            AstroDataReportConstants.NUM_LABELS_FAILED_TO_LOAD: 0,
-            AstroDataReportConstants.NUM_PROPERTIES_FAILED_TO_LOAD: 0
-        }
-
-        # Load data based on the test/train/validation sheet
-        for index, row in self.dataset_split_df.iterrows():
-            try:
-                tic_id = int(row[DataManagerConstants.TIC_ID_COLUMN])
-                split = row[DataManagerConstants.SPLIT_COLUMN]
-
-                labels_row = self.labels_df[self.labels_df[DataManagerConstants.TIC_ID_COLUMN] == tic_id]
-                labels_dict = labels_row.to_dict(orient='records')[0] if not labels_row.empty else {}
-                if not labels_dict:
-                    astro_data_report[AstroDataReportConstants.NUM_LABELS_FAILED_TO_LOAD] += 1
-                    continue
-
-                label = labels_dict[DataManagerConstants.LABEL_COLUMN]
-                astro_id = labels_dict[DataManagerConstants.ASTRO_ID_COLUMN]
-
-                properties_row = self.properties_df[self.properties_df[DataManagerConstants.TIC_ID_COLUMN] == tic_id]
-                properties_dict = (
-                    {to_camel_case(k): v for k, v in properties_row.to_dict(orient='records')[0].items()}
-                    if not properties_row.empty else {}
-                )
-
-                properties_dict.update(
-                    {
-                        'distinct': labels_dict.get(DataManagerConstants.DISTINCT_COLUMN),
-                        'astronet_note': labels_dict.get(DataManagerConstants.ASTRONET_NOTE_COLUMN)
-                    }
-                )
-
-                fits_path = self.data_storage.get_path(tic_id=tic_id)
-                if not fits_path:
-                    astro_data_report[AstroDataReportConstants.NUM_FITS_FAILED_TO_LOAD] += 1
-                    continue
-
-
-                astro_data.append(AstroData(
-                    astro_id=astro_id,
-                    tic_id=tic_id,
-                    fits_path=fits_path,
-                    report_path=None,
-                    properties=properties_dict,
-                    label=label,
-                ))
-                astro_data_report[AstroDataReportConstants.NUM_SUCCESSFUL_LOADS] += 1
-            except Exception as e:
-                print(f'Failed to load tic_id={tic_id} with exception ' + str(e) + ', skipping...')
-
-        report = AstroDataReport(
-            num_successful_loads=astro_data_report.get(AstroDataReportConstants.NUM_SUCCESSFUL_LOADS, 0),
-            num_fits_failed_to_load=astro_data_report.get(AstroDataReportConstants.NUM_FITS_FAILED_TO_LOAD, 0),
-            num_labels_failed_to_load=astro_data_report.get(AstroDataReportConstants.NUM_LABELS_FAILED_TO_LOAD, 0),
-            num_properties_failed_to_load=astro_data_report.get(AstroDataReportConstants.NUM_PROPERTIES_FAILED_TO_LOAD, 0)
-        )
-        return (astro_data, report)
-
-    def get_data_from_tic_id(self, tic_id: int) -> AstroData:
-            data = self.tic_id_to_data.get(tic_id)
-            if not data:
-                raise Exception(f"Data not found for tic id {tic_id}")
-            return data
-
-
     def __init__(self):
         print(f'Loading dataset from dataset_config:\n{dataset_config}\n')
         self.data_dir = dataset_config.raw_data_dir
@@ -142,6 +70,69 @@ class DataManager:
         for data in self.astro_data:
             self.tic_id_to_data[data.tic_id] = data
         print(str(report) + '\n')
+
+    def _init_astro_data(self) -> tuple[list[AstroData], AstroDataReport]:
+        astro_data = []
+        astro_data_report = AstroDataReport()
+        # Load data based on the test/train/validation sheet
+        for index, row in self.dataset_split_df.iterrows():
+            try:
+                tic_id = int(row[DataManagerConstants.TIC_ID_COLUMN])
+                split = row[DataManagerConstants.SPLIT_COLUMN]
+
+                labels_row = self.labels_df[self.labels_df[DataManagerConstants.TIC_ID_COLUMN] == tic_id]
+                labels_dict = labels_row.to_dict(orient='records')[0] if not labels_row.empty else {}
+                if not labels_dict:
+                    astro_data_report.num_labels_failed_to_load += 1
+                    continue
+
+                label = labels_dict[DataManagerConstants.LABEL_COLUMN]
+                astro_id = labels_dict[DataManagerConstants.ASTRO_ID_COLUMN]
+
+                properties_row = self.properties_df[self.properties_df[DataManagerConstants.TIC_ID_COLUMN] == tic_id]
+                properties_dict = (
+                    {to_camel_case(k): v for k, v in properties_row.to_dict(orient='records')[0].items()}
+                    if not properties_row.empty else {}
+                )
+
+                properties_dict.update(
+                    {
+                        'distinct': labels_dict.get(DataManagerConstants.DISTINCT_COLUMN),
+                        'astronet_note': labels_dict.get(DataManagerConstants.ASTRONET_NOTE_COLUMN)
+                    }
+                )
+
+                fits_path = self.data_storage.get_path(tic_id=tic_id)
+                if not fits_path:
+                    astro_data_report.num_fits_failed_to_load += 1
+                    continue
+
+
+                astro_data.append(AstroData(
+                    astro_id=astro_id,
+                    tic_id=tic_id,
+                    fits_path=fits_path,
+                    report_path=None,
+                    properties=properties_dict,
+                    label=label,
+                ))
+                astro_data_report.num_successful_loads += 1
+            except Exception as e:
+                print(f'Failed to load tic_id={tic_id} with exception ' + str(e) + ', skipping...')
+
+        report = AstroDataReport(
+            num_successful_loads=astro_data_report.num_successful_loads,
+            num_fits_failed_to_load=astro_data_report.num_fits_failed_to_load,
+            num_labels_failed_to_load=astro_data_report.num_labels_failed_to_load,
+            num_properties_failed_to_load=astro_data_report.num_properties_failed_to_load,
+        )
+        return (astro_data, report)
+
+    def get_data_from_tic_id(self, tic_id: int) -> AstroData:
+        data = self.tic_id_to_data.get(tic_id)
+        if data is not None:
+            raise Exception(f"Data not found for tic id {tic_id}")
+        return data
 
 data_manager = DataManager() # singleton
 

--- a/data_management/data_manager.py
+++ b/data_management/data_manager.py
@@ -1,11 +1,64 @@
+import re
 from pathlib import Path
 from config_parser import DatasetConfig
 from dataclasses import dataclass
-from data_management.astro_data import AstroData
+from data_management.astro_data import AstroData, Split
 from data_management.google_sheets_reader import GoogleSheetsReader
 from data_management.data_storage import DataStorage
+import pandas as pd
+import traceback
 
 dataset_config = DatasetConfig.from_yaml()
+
+dtype_dict = {
+    # Integer IDs (Nullable to handle missing values)
+    "astro_id": "Int64",
+    "tic_id": "Int64",
+
+    # File Paths / Text Columns
+    "fits_path": "string",
+    "report_paths": "string",
+    "filename": "string",
+    "comment": "string",
+
+    # Categorical/String Columns
+    "label": "string",
+    "label_simplified": "string",
+    "split": "string",
+    "final": "string",
+    "decision": "string",
+    "distinct": "string",
+    "mk": "string",
+    "ch": "string",
+    "et": "string",
+    "md": "string",
+    "as": "string",
+    "dm": "string",
+    "tansu": "string",
+    "shishir": "string",
+    "jh": "string",
+    "astronet_note": "string",
+    "sectors": "string",
+
+    # Numerical Values (Floats)
+    "ra": "float64",
+    "dec": "float64",
+    "tmag": "float64",
+    "epoc": "float64",
+    "period": "float64",
+    "duration": "float64",
+    "transit_depth": "float64",
+    "star_rad": "float64",
+    "star_mass": "float64",
+    "teff": "float64",
+    "logg": "float64",
+    "sn": "float64",
+    "qingress": "float64",
+    "star_rad_est": "float64",
+
+    # Random Seed (Nullable Integer)
+    "seed_randbetween(1,_100)": "string",
+}
 
 @dataclass
 class AstroDataReport:
@@ -13,21 +66,6 @@ class AstroDataReport:
     num_fits_failed_to_load: int = 0
     num_labels_failed_to_load: int = 0
     num_properties_failed_to_load: int = 0
-
-class DataManagerConstants:
-    TIC_ID_COLUMN = "TIC ID"
-    SPLIT_COLUMN = "Split" # Comes from dataset split sheet
-    LABEL_COLUMN = "Final" # Comes from labels sheet
-    ASTRO_ID_COLUMN = "Astro ID" # Comes from all sheets (primary key)
-    DISTINCT_COLUMN = "Distinct" # Comes from labels sheet
-    ASTRONET_NOTE_COLUMN = "Astronet note" # Comes from labels sheet (human notes about the labels)
-
-@dataclass
-class AstroDataReport:
-    num_successful_loads: int
-    num_fits_failed_to_load: int
-    num_labels_failed_to_load: int
-    num_properties_failed_to_load: int
 
     def __str__(self):
         return (
@@ -37,6 +75,14 @@ class AstroDataReport:
             f"  - Labels Failed to Load: {self.num_labels_failed_to_load}\n"
             f"  - Properties Failed to Load: {self.num_properties_failed_to_load}"
         )
+    
+class DataManagerConstants:
+    TIC_ID_COLUMN = "tic_id"
+    SPLIT_COLUMN = "split" # Comes from dataset split sheet
+    LABEL_COLUMN = "final" # Comes from labels sheet
+    ASTRO_ID_COLUMN = "astro_id" # Comes from all sheets (primary key)
+    DISTINCT_COLUMN = "distinct" # Comes from labels sheet
+    ASTRONET_NOTE_COLUMN = "astronet_note" # Comes from labels sheet (human notes about the labels)
 
 def to_camel_case(s: str):
     return s.lower().replace(' ', '_')
@@ -53,16 +99,20 @@ class DataManager:
     def __init__(self):
         print(f'Loading dataset from dataset_config:\n{dataset_config}\n')
         self.data_dir = dataset_config.raw_data_dir
-        self.data_storage = DataStorage(data_dir=self.data_dir)
+        self.data_storage = DataStorage(data_dir=self.data_dir, images_dir=dataset_config.images_dir, reports_dir=dataset_config.reports_dir)
 
         # Read sheets
         labels_sheet = dataset_config.labels_sheet
         sheets_reader = GoogleSheetsReader()
+        self.sheets_reader = sheets_reader
         self.labels_df = sheets_reader.from_url(labels_sheet)
+        self.labels_df = self.convert_columns_to_snake_case(self.labels_df)
         properties_sheet = dataset_config.properties_sheet
         self.properties_df = sheets_reader.from_url(properties_sheet)
+        self.properties_df = self.convert_columns_to_snake_case(self.properties_df)
         dataset_split_sheet = dataset_config.dataset_split_sheet
         self.dataset_split_df = sheets_reader.from_url(dataset_split_sheet)
+        self.dataset_split_df = self.convert_columns_to_snake_case(self.dataset_split_df)
 
         # Init data
         (self.astro_data, report) = self._init_astro_data()
@@ -78,7 +128,8 @@ class DataManager:
         for index, row in self.dataset_split_df.iterrows():
             try:
                 tic_id = int(row[DataManagerConstants.TIC_ID_COLUMN])
-                split = row[DataManagerConstants.SPLIT_COLUMN]
+                split = Split.from_str(row[DataManagerConstants.SPLIT_COLUMN])
+
 
                 labels_row = self.labels_df[self.labels_df[DataManagerConstants.TIC_ID_COLUMN] == tic_id]
                 labels_dict = labels_row.to_dict(orient='records')[0] if not labels_row.empty else {}
@@ -106,19 +157,26 @@ class DataManager:
                 if not fits_path:
                     astro_data_report.num_fits_failed_to_load += 1
                     continue
+                
+                images_path = self.data_storage.get_images_path(tic_id=tic_id)
+                report_paths = self.data_storage.get_reports_path(tic_id=tic_id)
+
 
 
                 astro_data.append(AstroData(
                     astro_id=astro_id,
                     tic_id=tic_id,
                     fits_path=fits_path,
-                    report_path=None,
+                    images_path=images_path,
+                    report_paths=report_paths,
                     properties=properties_dict,
                     label=label,
+                    split=split.value,
                 ))
                 astro_data_report.num_successful_loads += 1
             except Exception as e:
                 print(f'Failed to load tic_id={tic_id} with exception ' + str(e) + ', skipping...')
+                traceback.print_exc()
 
         report = AstroDataReport(
             num_successful_loads=astro_data_report.num_successful_loads,
@@ -128,11 +186,51 @@ class DataManager:
         )
         return (astro_data, report)
 
+    def to_snake_case(self, s):
+        s = re.sub(r'\s+', '_', s)  # Replace spaces with underscores
+        s = re.sub(r'([a-z0-9])([A-Z])', r'\1_\2', s)  # Insert underscore before uppercase letters preceded by lowercase or number
+        s = re.sub(r'[^a-zA-Z0-9_]', '', s)  # Remove non-alphanumeric characters except underscores
+        return s.lower().strip('_')  # Convert to lowercase and remove leading/trailing underscores
+    
+    def convert_columns_to_snake_case(self, df):
+        df.columns = [self.to_snake_case(col) for col in df.columns]
+        return df
+
     def get_data_from_tic_id(self, tic_id: int) -> AstroData:
         data = self.tic_id_to_data.get(tic_id)
         if data is not None:
             raise Exception(f"Data not found for tic id {tic_id}")
         return data
+
+    def get_data_frame(self) -> pd.DataFrame:
+        """
+        Returns a DataFrame of all AstroData objects with properties unpacked.
+        """
+        TRUE_MAPPING = {
+            "eb": "Eclipsing Binary", "ebs": "Eclipsing Binary", "et": "Eclipsing Binary", "eu": "Eclipsing Binary",
+            "ets": "Eclipsing Binary", "eus": "Eclipsing Binary", "pt": "Planet", "pb": "Planet", "pu": "Planet",
+            "pts": "Planet", "pus": "Planet", "nt": "Noise", "nb": "Noise", "nu": "Noise", "jj": "Junk",
+            "ub": "Unknown", "i": "Indeterminate"
+        }
+        data_list = []
+        for data in self.astro_data:
+            label_simplified = TRUE_MAPPING.get(data.label)
+            data_dict = {
+                'astro_id': data.astro_id,
+                'tic_id': data.tic_id,
+                'fits_path': data.fits_path,
+                'report_paths': data.report_paths,
+                'label': data.label,
+                'label_simplified': label_simplified,
+                'split': data.split,
+            }
+            data_dict.update(data.properties)
+            data_list.append(data_dict)
+        
+        df = pd.DataFrame(data_list)
+        filtered_dtype_dict = {col: dtype for col, dtype in dtype_dict.items() if col in df.columns}
+        df = df.astype(filtered_dtype_dict)
+        return df
 
 data_manager = DataManager() # singleton
 

--- a/data_management/data_storage.py
+++ b/data_management/data_storage.py
@@ -1,0 +1,29 @@
+import os
+import sqlite3
+import re
+from typing import Optional
+from pathlib import Path
+
+
+class DataStorage:
+    def __init__(self, data_dir: Path) -> None:
+        self.tic_id_to_path = {}
+        for file in Path(data_dir).glob("*.fits"):
+            tic_id = self.extract_tic_id(file.name)
+            if tic_id is None:
+                print(f"Skipping {file.name}: TIC ID could not be extracted.")
+                continue
+
+            full_path = str(file.resolve())  # Get absolute OS path
+            self.tic_id_to_path[tic_id] = full_path
+
+
+    def extract_tic_id(self, filename: str) -> int:
+        """Extract TIC ID from the filename using regex."""
+        match = re.search(r'-(\d{9,})_', filename)
+        if match:
+            return int(match.group(1))
+        return None
+
+    def get_path(self, tic_id: int) -> Optional[Path]:
+        return self.tic_id_to_path.get(tic_id)

--- a/data_management/data_storage.py
+++ b/data_management/data_storage.py
@@ -1,5 +1,3 @@
-import os
-import sqlite3
 import re
 from typing import Optional
 from pathlib import Path
@@ -8,6 +6,8 @@ from pathlib import Path
 class DataStorage:
     def __init__(self, data_dir: Path) -> None:
         self.tic_id_to_path = {}
+        if ".." in str(data_dir): # enable both local and full paths
+            data_dir = data_dir.resolve()
         for file in Path(data_dir).glob("*.fits"):
             tic_id = self.extract_tic_id(file.name)
             if tic_id is None:

--- a/data_management/data_storage.py
+++ b/data_management/data_storage.py
@@ -1,12 +1,20 @@
 import re
 from pathlib import Path
+from collections import defaultdict
 
 
 class DataStorage:
-    def __init__(self, data_dir: Path) -> None:
+    def __init__(self, data_dir: Path, images_dir: Path, reports_dir: Path) -> None:
         self.tic_id_to_path: dict[int, str] = {}
+        self.tic_id_to_images_path: dict[int, str] = {}
         if not data_dir.is_absolute(): # enable both local and full paths
             data_dir = data_dir.resolve()
+        if not images_dir.is_absolute(): # enable both local and full paths
+            images_dir = images_dir.resolve()
+        if not reports_dir.is_absolute(): # enable both local and full paths
+            reports_dir = reports_dir.resolve()
+
+        # load raw data
         for file in Path(data_dir).glob("*.fits"):
             tic_id = self.extract_tic_id(file.name)
             if tic_id is None:
@@ -16,6 +24,24 @@ class DataStorage:
             full_path = str(file.resolve())  # Get absolute OS path
             self.tic_id_to_path[tic_id] = full_path
 
+        # load image
+        for folder in Path(images_dir).iterdir():
+            if folder.is_dir():
+                tic_id = int(folder.name)
+                full_path = str(folder.resolve())
+                self.tic_id_to_images_path[tic_id] = full_path
+
+        # load reports
+        self.tic_id_to_reports_path: dict[str, list[str]] = defaultdict(list)
+        # there can be N reports in the form <tic_id>.page<n>.png
+        for file in Path(reports_dir).glob("*.png"):
+            tic_id = int(str(file.name).split(".")[0])
+            if tic_id is None:
+                print(f"Skipping {file.name}: TIC ID could not be extracted.")
+                continue
+
+            full_path = str(file.resolve())
+            self.tic_id_to_reports_path[tic_id].append(full_path)
 
     def extract_tic_id(self, filename: str) -> int:
         """Extract TIC ID from the filename using regex."""
@@ -26,3 +52,9 @@ class DataStorage:
 
     def get_path(self, tic_id: int) -> str | None:
         return self.tic_id_to_path.get(tic_id)
+
+    def get_images_path(self, tic_id: int) -> Path | None:
+        return self.tic_id_to_images_path.get(tic_id)
+    
+    def get_reports_path(self, tic_id: int) -> Path | None:
+        return self.tic_id_to_reports_path.get(tic_id, [])

--- a/data_management/data_storage.py
+++ b/data_management/data_storage.py
@@ -1,12 +1,11 @@
 import re
-from typing import Optional
 from pathlib import Path
 
 
 class DataStorage:
     def __init__(self, data_dir: Path) -> None:
-        self.tic_id_to_path = {}
-        if ".." in str(data_dir): # enable both local and full paths
+        self.tic_id_to_path: dict[int, str] = {}
+        if not data_dir.is_absolute(): # enable both local and full paths
             data_dir = data_dir.resolve()
         for file in Path(data_dir).glob("*.fits"):
             tic_id = self.extract_tic_id(file.name)
@@ -25,5 +24,5 @@ class DataStorage:
             return int(match.group(1))
         return None
 
-    def get_path(self, tic_id: int) -> Optional[Path]:
+    def get_path(self, tic_id: int) -> str | None:
         return self.tic_id_to_path.get(tic_id)

--- a/data_management/google_sheets_reader.py
+++ b/data_management/google_sheets_reader.py
@@ -1,0 +1,25 @@
+import pandas as pd
+
+class GoogleSheetsReader:
+    @staticmethod
+    def from_url(url: str, page_num: int = 0) -> pd.DataFrame:
+        """
+        Fetches data from a public Google Sheet and returns it as a Pandas DataFrame.
+
+        :param url: The Google Sheets URL.
+        :param page_num: The index of the sheet (default is 0, the first sheet).
+        :return: Pandas DataFrame with the sheet data.
+        """
+        try:
+            if "docs.google.com/spreadsheets/d/" not in url:
+                raise ValueError("Invalid Google Sheets URL.")
+
+            sheet_id = url.split("/d/")[1].split("/")[0]
+            csv_url = f"https://docs.google.com/spreadsheets/d/{sheet_id}/gviz/tq?tqx=out:csv&sheet={page_num}"
+
+            df = pd.read_csv(csv_url)
+            return df
+
+        except Exception as e:
+            print(f"Error fetching Google Sheet data: {e}")
+            return pd.DataFrame()

--- a/data_management/google_sheets_reader.py
+++ b/data_management/google_sheets_reader.py
@@ -3,11 +3,6 @@ import pandas as pd
 import gspread
 from google.oauth2.service_account import Credentials
 
-import os
-import pandas as pd
-import gspread
-from google.oauth2.service_account import Credentials
-
 class GoogleSheetsReader:
     def __init__(self):
         """

--- a/data_management/google_sheets_reader.py
+++ b/data_management/google_sheets_reader.py
@@ -1,25 +1,68 @@
+import os
 import pandas as pd
+import gspread
+from google.oauth2.service_account import Credentials
+
+import os
+import pandas as pd
+import gspread
+from google.oauth2.service_account import Credentials
 
 class GoogleSheetsReader:
-    @staticmethod
-    def from_url(url: str, page_num: int = 0) -> pd.DataFrame:
+    def __init__(self):
         """
-        Fetches data from a public Google Sheet and returns it as a Pandas DataFrame.
+        Initializes the Google Sheets Reader using an environment variable for authentication.
+        """
+        self.client = self.authenticate()
+
+    def authenticate(self):
+        """
+        Authenticates the service account with Google Sheets API using the credentials from an environment variable.
+        """
+        try:
+            credentials_path = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+            if not credentials_path:
+                raise ValueError("Google service account credentials file not found in environment variables.")
+
+            scopes = ["https://www.googleapis.com/auth/spreadsheets",
+                      "https://www.googleapis.com/auth/drive"]
+            creds = Credentials.from_service_account_file(credentials_path, scopes=scopes)
+            return gspread.authorize(creds)
+        except Exception as e:
+            print(f"Authentication Error: {e}")
+            return None
+
+    def from_url(self, url: str, sheet_name: str = None) -> pd.DataFrame:
+        """
+        Fetches data from a Google Sheet (public or private) and returns it as a Pandas DataFrame.
 
         :param url: The Google Sheets URL.
-        :param page_num: The index of the sheet (default is 0, the first sheet).
+        :param sheet_name: The name of the sheet (default is the first sheet).
         :return: Pandas DataFrame with the sheet data.
         """
         try:
+            if not self.client:
+                raise ValueError("Google Sheets authentication failed.")
+
             if "docs.google.com/spreadsheets/d/" not in url:
                 raise ValueError("Invalid Google Sheets URL.")
 
+            # Extract the Google Sheet ID from the URL
             sheet_id = url.split("/d/")[1].split("/")[0]
-            csv_url = f"https://docs.google.com/spreadsheets/d/{sheet_id}/gviz/tq?tqx=out:csv&sheet={page_num}"
+            spreadsheet = self.client.open_by_key(sheet_id)
 
-            df = pd.read_csv(csv_url)
+            # Select the specific sheet
+            if sheet_name:
+                worksheet = spreadsheet.worksheet(sheet_name)
+            else:
+                worksheet = spreadsheet.get_worksheet(0)  # Default to the first sheet
+
+            # Get all data as records (list of dictionaries)
+            data = worksheet.get_all_records()
+            df = pd.DataFrame(data)
+
             return df
 
         except Exception as e:
-            print(f"Error fetching Google Sheet data: {e}")
+            print(f"Error fetching Google Sheet data: {e} (did you share the service account? astronet-sheets-reader@astronet-452402.iam.gserviceaccount.com)")
             return pd.DataFrame()

--- a/data_management/google_sheets_reader.py
+++ b/data_management/google_sheets_reader.py
@@ -47,7 +47,7 @@ class GoogleSheetsReader:
             spreadsheet = self.client.open_by_key(sheet_id)
 
             # Select the specific sheet
-            if sheet_name:
+            if sheet_name is not None:
                 worksheet = spreadsheet.worksheet(sheet_name)
             else:
                 worksheet = spreadsheet.get_worksheet(0)  # Default to the first sheet

--- a/data_management/google_sheets_reader.py
+++ b/data_management/google_sheets_reader.py
@@ -2,6 +2,7 @@ import os
 import pandas as pd
 import gspread
 from google.oauth2.service_account import Credentials
+import numpy as np
 
 class GoogleSheetsReader:
     def __init__(self):
@@ -55,6 +56,7 @@ class GoogleSheetsReader:
             # Get all data as records (list of dictionaries)
             data = worksheet.get_all_records()
             df = pd.DataFrame(data)
+            df.replace(["#N/A", "", "N/A"], np.nan, inplace=True)  
 
             return df
 


### PR DESCRIPTION
Create a data management library for linking together data from various sources, ultimately with the goal of simplifying the data loading process into all of the different notebooks and codebase locations.
1. Google sheets are loaded live so that you don't need to pull them locally
2. Abstract different functionalities to different sheets, so that you don't need to manually merge them
3. Connect the TIC ID and properties directly with the raw data/FITS path

Tested with:
```
python -m data_management.data_manager
Loading dataset from dataset_config:
DatasetConfig(
        raw_data_source_type=local
        raw_data_dir=C:\TESS\data\lc\Vetting
        labels_sheet=<my_sheet_url>
        properties_sheet=<my_sheet_url>
        dataset_split_sheet=<my_sheet_url>
)

AstroDataReport:
  - # Successful Load: 2286
  - FITS Files Failed to Load: 7058
  - Labels Failed to Load: 0
  - Properties Failed to Load: 0
```