### PR TITLE
Add lightcurve utility functions directly into AstroData

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pyc
+config.yaml

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,6 @@
+dataset:
+  raw_data_source_type: "local"
+  raw_data_dir: "<path>" # fill your path here (local or PDO)
+  labels_sheet: '<url>' # Google sheets URL - sheet must be public. Should contain (Astro ID, TIC ID, Final)
+  properties_sheet: '<url>' # Should contain (TIC ID, Other Properties)
+  dataset_split_sheet: '<url>' # Should contain (TIC ID, Split)

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 dataset:
   raw_data_source_type: "local"
-  raw_data_dir: "<path>" # fill your path here (local or PDO)
-  labels_sheet: '<url>' # Google sheets URL - sheet must be public. Should contain (Astro ID, TIC ID, Final)
-  properties_sheet: '<url>' # Should contain (TIC ID, Other Properties)
-  dataset_split_sheet: '<url>' # Should contain (TIC ID, Split)
+  raw_data_dir: "C:\\TESS\\data\\lc\\Vetting"
+  labels_sheet: 'https://docs.google.com/spreadsheets/d/17-ByYBQ1uPweKH2P_4MWGWsuTKkEKrNFS4uGBsm-bGI/edit?gid=0#gid=0'
+  properties_sheet: 'https://docs.google.com/spreadsheets/d/1esYObG5TU2MQYOzvMklvYcwsYdTpWy5-BHpDaxgLDj8/edit?gid=789406476#gid=789406476'
+  dataset_split_sheet: 'https://docs.google.com/spreadsheets/d/1w_YvlGCQpdlPPC7JJgAUDANU2JU0cC9P-gwMeoYvMw8/edit?gid=0#gid=0'

--- a/config_parser.py
+++ b/config_parser.py
@@ -69,6 +69,14 @@ class DatasetConfig:
             dataset_split_sheet=dataset.get(Constants.DATASET_SPLIT_SHEET),
         )
 
+    def __str__(self) -> str:
+        return "DatasetConfig(\n\t" \
+            f"raw_data_source_type={self.raw_data_source_type}\n\t" \
+            f"raw_data_dir={self.raw_data_dir}\n\t" \
+            f"labels_sheet={self.labels_sheet}\n\t" \
+            f"properties_sheet={self.properties_sheet}\n\t" \
+            f"dataset_split_sheet={self.dataset_split_sheet}\n)"
+
 if __name__ == "__main__":
     dataset_config = DatasetConfig.from_yaml("config.yaml")
     print(f'Loaded dataset config: {dataset_config}')

--- a/config_parser.py
+++ b/config_parser.py
@@ -1,0 +1,74 @@
+import yaml
+from dataclasses import dataclass
+from pathlib import Path
+import os
+
+"""
+HOW TO USE THIS API
+
+The config_parser is meant to be used to create a DatasetConfig which is an
+input to a DataManager.
+
+By filling out config.yaml, you can maintain a single dataset object to use in
+every notebook rather than filling out individually all of the sheets you need.
+Sheets can also be loaded dynamically live from Google to keep the latest
+source of truth.
+
+"""
+
+class Constants:
+    """String constants used throughout the project."""
+
+    CONFIG_FILE: str = "config.yaml"
+
+    # Dataset keys
+    DATASET: str = "dataset"
+    RAW_DATA_SOURCE_TYPE: str = "raw_data_source_type"
+    RAW_DATA_DIR: str = "raw_data_dir"
+
+    # Source Types
+    LOCAL: str = "local"
+    REMOTE: str = "remote"
+
+    # Sheets
+    LABELS_SHEET: str = "labels_sheet"
+    PROPERTIES_SHEET: str = "properties_sheet"
+    DATASET_SPLIT_SHEET: str = "dataset_split_sheet"
+
+@dataclass
+class DatasetConfig:
+    """Dataclass to store dataset configuration."""
+    raw_data_source_type: str
+    raw_data_dir: Path
+    labels_sheet: str
+    properties_sheet: str
+    dataset_split_sheet: str
+
+    @staticmethod
+    def from_yaml(config_path: str = Constants.CONFIG_FILE) -> "DatasetConfig":
+        """Reads YAML configuration and returns a DatasetConfig instance."""
+
+        config_file = Path(config_path)
+
+        if not config_file.exists():
+            raise FileNotFoundError(f"Config file not found: {config_file}")
+
+        with open(config_file, "r") as file:
+            config = yaml.safe_load(file)
+
+        if Constants.DATASET not in config:
+            raise ValueError(f"Invalid config format: Missing '{Constants.DATASET}' section.")
+
+        dataset = config[Constants.DATASET]
+
+        return DatasetConfig(
+            raw_data_source_type=dataset.get(Constants.RAW_DATA_SOURCE_TYPE),
+            raw_data_dir=Path(dataset.get(Constants.RAW_DATA_DIR)),
+            labels_sheet=dataset.get(Constants.LABELS_SHEET),
+            properties_sheet=dataset.get(Constants.PROPERTIES_SHEET),
+            dataset_split_sheet=dataset.get(Constants.DATASET_SPLIT_SHEET),
+        )
+
+if __name__ == "__main__":
+    dataset_config = DatasetConfig.from_yaml("config.yaml")
+    print(f'Loaded dataset config: {dataset_config}')

--- a/data_management/astro_data.py
+++ b/data_management/astro_data.py
@@ -15,6 +15,98 @@ class AstroData:
     properties: Dict[str, Any]
     label: Optional[str] = None
 
+    def read_light_curve(self, flux_key: str, min_t: int, max_t: int) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Reads a TESS light curve from a FITS file and filters the data based on the provided time range.
+        
+        Args:
+            flux_key (str): The key to extract the desired flux type from the FITS file.
+            min_t (int): The minimum time value for filtering.
+            max_t (int): The maximum time value for filtering.
+        
+        Returns:
+            Tuple[np.ndarray, np.ndarray]: Filtered time and flux arrays.
+        
+        Raises:
+            AssertionError: If no data points remain after filtering.
+        """
+        time, flux = tess_io.read_tess_light_curve(self.fits_path, flux_key)
+        mask = (time >= min_t) & (time <= max_t)
+
+        filtered_time = time[mask]
+        filtered_flux = flux[mask]
+
+        assert len(filtered_time), "No data points remain after filtering."
+        return filtered_time, filtered_flux
+
+    def filter_outliers(self, time: np.ndarray, flux: np.ndarray, mask: np.ndarray) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """
+        Removes NaN values from the flux data while keeping time and mask aligned.
+        
+        Args:
+            time (np.ndarray): The time array of the light curve.
+            flux (np.ndarray): The flux measurements corresponding to the time array.
+            mask (np.ndarray): A boolean mask used to filter data points.
+        
+        Returns:
+            Tuple[np.ndarray, np.ndarray, np.ndarray]: Arrays of time, flux, and mask after removing NaN values.
+        """
+        valid = ~np.isnan(flux)
+        return time[valid], flux[valid], mask[valid]
+
+    def detrend_and_filter(
+        self, time: np.ndarray, flux: np.ndarray, fixed_bkspace: float
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Detrends the light curve using the Kepler Spline algorithm and filters outliers.
+        
+        Args:
+            time (np.ndarray): The time array of the light curve.
+            flux (np.ndarray): The flux measurements corresponding to the time array.
+            fixed_bkspace (float): Fixed break-space parameter for the spline fit.
+        
+        Returns:
+            Tuple[np.ndarray, np.ndarray]: Time and detrended flux arrays after filtering.
+        """
+        mask = self.get_spline_mask(time)
+        spline_flux, metadata = keplersplinev2.choosekeplersplinev2(
+            time, flux, input_mask=mask, fixed_bkspace=fixed_bkspace, return_metadata=True
+        )
+
+        detrended_flux = flux / spline_flux
+        return self.filter_outliers(time, detrended_flux, mask)
+
+    def phase_fold_and_sort_light_curve(
+        self, time: np.ndarray, flux: np.ndarray, mask: np.ndarray,
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """
+        Phase folds the light curve based on the known period and epoch, then sorts it by ascending time.
+        
+        Args:
+            time (np.ndarray): The time array of the light curve.
+            flux (np.ndarray): The flux measurements corresponding to the time array.
+            mask (np.ndarray): A boolean mask used to filter data points.
+        
+        Returns:
+            Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+                - Folded time array sorted in ascending order.
+                - Corresponding sorted flux array.
+                - Fold number array sorted accordingly.
+                - Sorted mask array.
+        """
+        if time.size == 0:
+            return np.array([]), np.array([]), np.array([]), np.array([])
+
+        folded_time, fold_num = util.phase_fold_time(time, self.period, self.epoc)
+        sorted_indices = np.argsort(folded_time)
+
+        return (
+            folded_time[sorted_indices],
+            flux[sorted_indices],
+            fold_num[sorted_indices],
+            mask[sorted_indices],
+        )
+
     @property
     def id(self) -> Optional[int]:
         return self.properties.get('id')

--- a/data_management/astro_data.py
+++ b/data_management/astro_data.py
@@ -1,0 +1,92 @@
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+from light_curve_util import tess_io
+from light_curve_util import keplersplinev2
+from light_curve_util import median_filter2
+from light_curve_util import util
+import numpy as np
+
+@dataclass
+class AstroData:
+    astro_id: int
+    tic_id: int
+    fits_path: str
+    report_path: Optional[str]
+    properties: Dict[str, Any]
+    label: Optional[str] = None
+
+    @property
+    def id(self) -> Optional[int]:
+        return self.properties.get('id')
+
+    @property
+    def version_id(self) -> Optional[int]:
+        return self.properties.get('version_id')
+
+    @property
+    def ra(self) -> Optional[float]:
+        return self.properties.get('ra')
+
+    @property
+    def dec(self) -> Optional[float]:
+        return self.properties.get('dec')
+
+    @property
+    def tmag(self) -> Optional[float]:
+        return self.properties.get('tmag')
+
+    @property
+    def epoc(self) -> Optional[float]:
+        return self.properties.get('epoc')
+
+    @property
+    def period(self) -> Optional[float]:
+        return self.properties.get('period')
+
+    @property
+    def duration(self) -> Optional[float]:
+        return self.properties.get('duration')
+
+    @property
+    def transit_depth(self) -> Optional[float]:
+        return self.properties.get('transit_depth')
+
+    @property
+    def sectors(self) -> Optional[Any]:
+        return self.properties.get('sectors')
+
+    @property
+    def star_rad(self) -> Optional[float]:
+        return self.properties.get('star_rad')
+
+    @property
+    def star_mass(self) -> Optional[float]:
+        return self.properties.get('star_mass')
+
+    @property
+    def teff(self) -> Optional[float]:
+        return self.properties.get('teff')
+
+    @property
+    def logg(self) -> Optional[float]:
+        return self.properties.get('logg')
+
+    @property
+    def sn(self) -> Optional[float]:
+        return self.properties.get('sn')
+
+    @property
+    def qingress(self) -> Optional[float]:
+        return self.properties.get('qingress')
+
+    @property
+    def star_rad_est(self) -> Optional[float]:
+        return self.properties.get('star_rad_est')
+
+    @property
+    def filename(self) -> Optional[str]:
+        return self.properties.get('filename')
+
+    @property
+    def comment(self) -> Optional[str]:
+        return self.properties.get('comment')

--- a/data_management/data_manager.py
+++ b/data_management/data_manager.py
@@ -1,0 +1,150 @@
+from pathlib import Path
+from config_parser import DatasetConfig
+import pandas as pd
+from typing import List, Tuple
+from dataclasses import dataclass
+from data_management.astro_data import AstroData
+from data_management.google_sheets_reader import GoogleSheetsReader
+from data_management.data_storage import DataStorage
+
+dataset_config = DatasetConfig.from_yaml()
+
+class AstroDataReportConstants:
+    NUM_SUCCESSFUL_LOADS = 'num_successful_loads'
+    NUM_FITS_FAILED_TO_LOAD = 'num_fits_failed_to_load'
+    NUM_LABELS_FAILED_TO_LOAD = 'num_labels_failed_to_load'
+    NUM_PROPERTIES_FAILED_TO_LOAD = 'num_properties_failed_to_load'
+
+class DataManagerConstants:
+    TIC_ID_COLUMN = "TIC ID"
+    SPLIT_COLUMN = "Split"
+    LABEL_COLUMN = "Final"
+    ASTRO_ID_COLUMN = "Astro ID"
+    DISTINCT_COLUMN = "Distinct"
+    ASTRONET_NOTE_COLUMN = "Astronet note"
+
+@dataclass
+class AstroDataReport:
+    num_successful_loads: int
+    num_fits_failed_to_load: int
+    num_labels_failed_to_load: int
+    num_properties_failed_to_load: int
+
+    def __str__(self):
+        return (
+            "AstroDataReport:\n"
+            f"  - # Successful Load: {self.num_successful_loads}\n"
+            f"  - FITS Files Failed to Load: {self.num_fits_failed_to_load}\n"
+            f"  - Labels Failed to Load: {self.num_labels_failed_to_load}\n"
+            f"  - Properties Failed to Load: {self.num_properties_failed_to_load}"
+        )
+
+def to_camel_case(s: str):
+    return s.lower().replace(' ', '_')
+
+class DataManager:
+    """
+    Links all data sources together into AstroData objects.
+
+    Utilizes the Google sheets + storage directory. Rows are loaded based on
+    the test/train/validation split sheet, so that no other data is loaded if it
+    is not needed.
+    """
+
+
+    def _init_astro_data(self) -> Tuple[List[AstroData], AstroDataReport]:
+        astro_data = []
+        astro_data_report = {
+            AstroDataReportConstants.NUM_SUCCESSFUL_LOADS: 0,
+            AstroDataReportConstants.NUM_FITS_FAILED_TO_LOAD: 0,
+            AstroDataReportConstants.NUM_LABELS_FAILED_TO_LOAD: 0,
+            AstroDataReportConstants.NUM_PROPERTIES_FAILED_TO_LOAD: 0
+        }
+
+        # Load data based on the test/train/validation sheet
+        for index, row in self.dataset_split_df.iterrows():
+            try:
+                tic_id = int(row[DataManagerConstants.TIC_ID_COLUMN])
+                split = row[DataManagerConstants.SPLIT_COLUMN]
+
+                labels_row = self.labels_df[self.labels_df[DataManagerConstants.TIC_ID_COLUMN] == tic_id]
+                labels_dict = labels_row.to_dict(orient='records')[0] if not labels_row.empty else {}
+                if not labels_dict:
+                    astro_data_report[AstroDataReportConstants.NUM_LABELS_FAILED_TO_LOAD] += 1
+                    continue
+
+                label = labels_dict[DataManagerConstants.LABEL_COLUMN]
+                astro_id = labels_dict[DataManagerConstants.ASTRO_ID_COLUMN]
+
+                properties_row = self.properties_df[self.properties_df[DataManagerConstants.TIC_ID_COLUMN] == tic_id]
+                properties_dict = (
+                    {to_camel_case(k): v for k, v in properties_row.to_dict(orient='records')[0].items()}
+                    if not properties_row.empty else {}
+                )
+
+                properties_dict.update(
+                    {
+                        'distinct': labels_dict.get(DataManagerConstants.DISTINCT_COLUMN),
+                        'astronet_note': labels_dict.get(DataManagerConstants.ASTRONET_NOTE_COLUMN)
+                    }
+                )
+
+                fits_path = self.data_storage.get_path(tic_id=tic_id)
+                if not fits_path:
+                    astro_data_report[AstroDataReportConstants.NUM_FITS_FAILED_TO_LOAD] += 1
+                    continue
+
+
+                astro_data.append(AstroData(
+                    astro_id=astro_id,
+                    tic_id=tic_id,
+                    fits_path=fits_path,
+                    report_path=None,
+                    properties=properties_dict,
+                    label=label,
+                ))
+                astro_data_report[AstroDataReportConstants.NUM_SUCCESSFUL_LOADS] += 1
+            except Exception as e:
+                print(f'Failed to load tic_id={tic_id} with exception ' + str(e) + ', skipping...')
+
+        report = AstroDataReport(
+            num_successful_loads=astro_data_report.get(AstroDataReportConstants.NUM_SUCCESSFUL_LOADS, 0),
+            num_fits_failed_to_load=astro_data_report.get(AstroDataReportConstants.NUM_FITS_FAILED_TO_LOAD, 0),
+            num_labels_failed_to_load=astro_data_report.get(AstroDataReportConstants.NUM_LABELS_FAILED_TO_LOAD, 0),
+            num_properties_failed_to_load=astro_data_report.get(AstroDataReportConstants.NUM_PROPERTIES_FAILED_TO_LOAD, 0)
+        )
+        return (astro_data, report)
+
+    def get_data_from_tic_id(self, tic_id: int) -> AstroData:
+            data = self.tic_id_to_data.get(tic_id)
+            if not data:
+                raise Exception(f"Data not found for tic id {tic_id}")
+            return data
+
+
+    def __init__(self):
+        print(f'Loading dataset from dataset_config:\n{dataset_config}\n')
+        self.data_dir = dataset_config.raw_data_dir
+        self.data_storage = DataStorage(data_dir=self.data_dir)
+
+        # Read sheets
+        labels_sheet = dataset_config.labels_sheet
+        self.labels_df = GoogleSheetsReader.from_url(labels_sheet)
+        properties_sheet = dataset_config.properties_sheet
+        self.properties_df = GoogleSheetsReader.from_url(properties_sheet)
+        dataset_split_sheet = dataset_config.dataset_split_sheet
+        self.dataset_split_df = GoogleSheetsReader.from_url(dataset_split_sheet)
+
+        # Init data
+        (self.astro_data, report) = self._init_astro_data()
+        self.tic_id_to_data = {}
+        for data in self.astro_data:
+            self.tic_id_to_data[data.tic_id] = data
+        print(str(report) + '\n')
+
+data_manager = DataManager() # singleton
+
+# Example usage:
+if __name__ == "__main__":
+    tic_id_example = 100100823
+    print(data_manager.tic_id_to_data[tic_id_example])

--- a/data_management/data_storage.py
+++ b/data_management/data_storage.py
@@ -1,0 +1,29 @@
+import os
+import sqlite3
+import re
+from typing import Optional
+from pathlib import Path
+
+
+class DataStorage:
+    def __init__(self, data_dir: Path) -> None:
+        self.tic_id_to_path = {}
+        for file in Path(data_dir).glob("*.fits"):
+            tic_id = self.extract_tic_id(file.name)
+            if tic_id is None:
+                print(f"Skipping {file.name}: TIC ID could not be extracted.")
+                continue
+
+            full_path = str(file.resolve())  # Get absolute OS path
+            self.tic_id_to_path[tic_id] = full_path
+
+
+    def extract_tic_id(self, filename: str) -> int:
+        """Extract TIC ID from the filename using regex."""
+        match = re.search(r'-(\d{9,})_', filename)
+        if match:
+            return int(match.group(1))
+        return None
+
+    def get_path(self, tic_id: int) -> Optional[Path]:
+        return self.tic_id_to_path.get(tic_id)

--- a/data_management/data_storage.py
+++ b/data_management/data_storage.py
@@ -1,5 +1,3 @@
-import os
-import sqlite3
 import re
 from typing import Optional
 from pathlib import Path
@@ -8,6 +6,8 @@ from pathlib import Path
 class DataStorage:
     def __init__(self, data_dir: Path) -> None:
         self.tic_id_to_path = {}
+        if ".." in str(data_dir): # enable both local and full paths
+            data_dir = data_dir.resolve()
         for file in Path(data_dir).glob("*.fits"):
             tic_id = self.extract_tic_id(file.name)
             if tic_id is None:

--- a/data_management/google_sheets_reader.py
+++ b/data_management/google_sheets_reader.py
@@ -1,0 +1,25 @@
+import pandas as pd
+
+class GoogleSheetsReader:
+    @staticmethod
+    def from_url(url: str, page_num: int = 0) -> pd.DataFrame:
+        """
+        Fetches data from a public Google Sheet and returns it as a Pandas DataFrame.
+
+        :param url: The Google Sheets URL.
+        :param page_num: The index of the sheet (default is 0, the first sheet).
+        :return: Pandas DataFrame with the sheet data.
+        """
+        try:
+            if "docs.google.com/spreadsheets/d/" not in url:
+                raise ValueError("Invalid Google Sheets URL.")
+
+            sheet_id = url.split("/d/")[1].split("/")[0]
+            csv_url = f"https://docs.google.com/spreadsheets/d/{sheet_id}/gviz/tq?tqx=out:csv&sheet={page_num}"
+
+            df = pd.read_csv(csv_url)
+            return df
+
+        except Exception as e:
+            print(f"Error fetching Google Sheet data: {e}")
+            return pd.DataFrame()


### PR DESCRIPTION
These functions used to be in preprocess/ which is meant for preparing data for training, however these are common functions required for useful visualizations and such can be pulled directly into the AstroData objects.