### PR TITLE
TFRecord Gen Improvements

### DIFF
--- a/astronet/gen_tce_csv.py
+++ b/astronet/gen_tce_csv.py
@@ -1,0 +1,41 @@
+
+import argparse
+import pandas as pd
+import glob
+import os
+import re
+
+parser = argparse.ArgumentParser(description="Generate a CSV with file paths and properties for generating TFRecords for a given sector. Assumes the FITS files are in /pdo/astronet-data/data/data/fits.")
+parser.add_argument('--sector', type=int, required=True, help='Sector number')
+args = parser.parse_args()
+sector = args.sector
+
+fits_pattern = f"/pdo/astronet-data/data/fits/sector-{sector}/*.fits"
+tce_properties_csv = f"/pdo/qlp-data/sector-{sector}/ffi/run/astronet-vetting-tce-catalog.csv"
+output_csv = f"/pdo/astronet-data/data/tfrecords/sector-{sector}/tces-sector{sector}.csv"
+
+# Step 1: Find all .fits files
+fits_files = glob.glob(fits_pattern)
+
+# Step 2: Extract TIC ID from filenames and store mapping
+fits_df = pd.DataFrame({
+    "File": fits_files,
+    "TIC ID": [
+        int(re.search(r'-(\d{16})_tess', os.path.basename(f)).group(1).lstrip('0'))
+        for f in fits_files
+        if re.search(r'-(\d{16})_tess', os.path.basename(f))
+    ]
+})
+
+# Step 3: Load the TCE properties CSV
+tce_df = pd.read_csv(tce_properties_csv)
+
+# Step 4: Merge on TIC ID
+merged = pd.merge(tce_df, fits_df, on="TIC ID", how="left")
+merged = merged.drop(columns=["Unnamed: 0"], errors="ignore")
+merged = merged.fillna("")
+
+# Step 5: Save result
+os.makedirs(os.path.dirname(output_csv), exist_ok=True)
+merged.to_csv(output_csv, index=False)
+print(f"Saved merged CSV to {output_csv}")

--- a/astronet/gen_tfrecords_vetting.sh
+++ b/astronet/gen_tfrecords_vetting.sh
@@ -2,14 +2,14 @@
 
 set -e
 
-LCDIR=../mnt/tess/lc_vetting_and_triage_symbolic_links
-NAME=vetting-v02-tois-triageJs-nocentroid
+LCDIR=/pdo/astronet-data/data/fits/sector-87/
+NAME=vetting-sector87-all
 
-python astronet/preprocess/generate_input_records.py --input_tce_csv_file=../mnt/tess/astronet/tces-${NAME}-train.csv --tess_data_dir=${LCDIR} --output_dir=../mnt/tess/astronet/tfrecords-${NAME}-train --mode=vetting --num_shards=5
+#python preprocess/generate_input_records.py --input_tce_csv_file=../mnt/tess/astronet/tces-${NAME}-train.csv --tess_data_dir=${LCDIR} --output_dir=../mnt/tess/astronet/tfrecords-${NAME}-train --mode=vetting --num_shards=5
 
-python astronet/preprocess/generate_input_records.py --input_tce_csv_file=../mnt/tess/astronet/tces-${NAME}-val.csv --tess_data_dir=${LCDIR} --output_dir=../mnt/tess/astronet/tfrecords-${NAME}-val --mode=vetting --num_shards=5
+#python preprocess/generate_input_records.py --input_tce_csv_file=../mnt/tess/astronet/tces-${NAME}-val.csv --tess_data_dir=${LCDIR} --output_dir=../mnt/tess/astronet/tfrecords-${NAME}-val --mode=vetting --num_shards=5
 
-python astronet/preprocess/generate_input_records.py --input_tce_csv_file=../mnt/tess/astronet/tces-${NAME}-test.csv --tess_data_dir=${LCDIR} --output_dir=../mnt/tess/astronet/tfrecords-${NAME}-test --mode=vetting --num_shards=5
+python astronet/preprocess/generate_input_records.py --input_tce_csv_file=/pdo/astronet-data/data/tfrecords/sector-87/tces-sector87.csv --tess_data_dir=${LCDIR} --output_dir=/pdo/astronet-data/data/tfrecords/sector-87 --mode=vetting --num_shards=25
 
 
 
@@ -20,4 +20,3 @@ python astronet/preprocess/generate_input_records.py --input_tce_csv_file=../mnt
 # python astronet/preprocess/generate_input_records.py --input_tce_csv_file=../mnt/tess/astronet/tces-vetting-v7-toi-val.csv --tess_data_dir=${LCDIR} --output_dir=../mnt/tess/astronet/tfrecords-vetting-8-toi-val --vetting_features=y --num_shards=2
 
 # # python astronet/preprocess/generate_input_records.py --input_tce_csv_file=../mnt/tess/astronet/tces-vetting-v7-toi-test.csv --tess_data_dir=${LCDIR} --output_dir=../mnt/tess/astronet/tfrecords-vetting-8-toi-test --vetting_features=y --num_shards=2
-

--- a/astronet/preprocess/generate_input_records.py
+++ b/astronet/preprocess/generate_input_records.py
@@ -21,6 +21,7 @@ import pandas as pd
 import tensorflow as tf
 from absl import app, logging
 from typing_extensions import Protocol
+import traceback
 
 from astronet.preprocess import preprocess
 
@@ -183,7 +184,11 @@ def _process_tce(
     mode: AstronetMode,
     training: bool
 ):
-  time, flux = get_lightcurve(tce['Astro ID'])
+  import time
+  start_time = time.time()
+  astro_id = tce['Astro ID']
+  logging.info(f'Starting to process {astro_id}')
+  tme, flux = get_lightcurve(tce['Astro ID'])
   if mode == 'vetting':
     apertures = {
       's': get_lightcurve(tce['Astro ID'], aperture='s'),
@@ -196,7 +201,7 @@ def _process_tce(
   ex = tf.train.Example()
 
   for bkspace in [0.3, 5.0, None]:
-    fold_num = _standard_views(ex, tce['TIC ID'], time, flux, tce.Per, tce.Epoc, tce.Dur, bkspace, apertures)
+    fold_num = _standard_views(ex, tce['TIC ID'], tme, flux, tce.Per, tce.Epoc, tce.Dur, bkspace, apertures)
 
   _set_int64_feature(ex, 'astro_id', [tce['Astro ID']])
 
@@ -256,145 +261,128 @@ def _process_tce(
   _set_float_feature(ex, 'n_folds', [len(set(fold_num))])
   _set_float_feature(ex, 'n_points', [len(fold_num)])
 
+  end_time = time.time()
+  logging.info(f'Finished processing {astro_id} in {end_time - start_time} seconds')
   return ex
 
+tce_table = None
 
-def _process_file_shard(
-  tce_table: pd.DataFrame,
-  file_name: str,
-  get_lightcurve: LCGetter,
-  mode: AstronetMode,
-  training: bool,
-):
-  process_name = multiprocessing.current_process().name
-  shard_name = os.path.basename(file_name)
-  shard_size = len(tce_table)
-    
-  existing = {}
-  try:
-    tfr = tf.data.TFRecordDataset(file_name)
-    for record in tfr:
-      ex_str = record.numpy()
-      ex = tf.train.Example.FromString(ex_str)
-      existing[ex.features.feature['astro_id'].int64_list.value[0]] = ex_str
-  except:
-    pass
+def get_lightcurve(astro_id: int, aperture: Optional[str] = None):
+    aperture_key_map = {
+        "s": "SAP_FLUX_SML",
+        "m": "SAP_FLUX_MID",
+        "l": "SAP_FLUX_LAG",
+        None: "SAP_FLUX",
+    }
+    global tce_table
+    matching_tces = tce_table[tce_table["Astro ID"] == astro_id] # tce_table.where(tce_table["Astro ID"] == astro_id)
+    try:
+        _, tce = next(matching_tces.iterrows())
+    except StopIteration as e:
+        raise ValueError(f"Astro ID not found: {astro_id}") from e
+    if "MinT" not in tce:
+        tce["MinT"] = -np.inf
+    if "MaxT" not in tce:
+        tce["MaxT"] = np.inf
+    return preprocess.read_and_process_light_curve(
+        FLAGS.tess_data_dir,
+        aperture_key_map[aperture],
+        tce.File,
+        tce.MinT,
+        tce.MaxT,
+    )
 
-  with tf.io.TFRecordWriter(file_name) as writer:
-    num_processed = 0
-    num_skipped = 0
-    num_existing = 0
-    print("", end='')
-    for _, tce in tce_table.iterrows():
-      num_processed += 1
-      recid = int(tce['Astro ID'])
-      print("\r                                      ", end="")
-      print(f"\r[{num_processed}/{shard_size}] {recid}", end="")
+class ProcessRecordWorker:
+    def __init__(self, existing, get_lightcurve, mode, training, _process_tce, tce_table, output_dir, augment_times):
+        self.existing = existing
+        self.get_lightcurve = get_lightcurve
+        self.mode = mode
+        self.training = training
+        self._process_tce = _process_tce
+        self.tce_table = tce_table
+        self.augment_times = augment_times
+        self.output_dir = output_dir
 
-      if recid in existing:
-        print(" exists", end="")
-        sys.stdout.flush()
-        writer.write(existing[recid])
-        num_existing += 1
-        continue
+    def __call__(self, tce_row_dict):
+        tce = pd.Series(tce_row_dict)
+        recid = int(tce['Astro ID'])
+        examples = []
 
-      examples = []
-      try:
-        print(" processing", end="")
-        sys.stdout.flush()
-        ex = _process_tce(tce, get_lightcurve, mode, training)
-        examples.append(ex)
-      except Exception as e:
-        raise
-        print(f" *** error: {e}")
-        num_skipped += 1
-        continue
+        try:
+            if recid in self.existing and self.augment_times == 0:
+                return [(self.existing[recid], 'reused', recid)]
 
-      print(" writing                   ", end="")
-      sys.stdout.flush()
-      for example in examples:
-        writer.write(example.SerializeToString())
+            # Original example: simply pass through the light curve
+            def passthrough_lc_getter(astro_id, aperture=None):
+                return self.get_lightcurve(astro_id, aperture)
+            
+            ex = self._process_tce(tce, passthrough_lc_getter, self.mode, self.training)
+            examples.append((ex.SerializeToString(), 'new', recid))
+
+            # Augmented examples
+            # TODO: add augmentation support which modifies the lc_getter
+        except Exception:
+            logging.info(traceback.logging.info_exc())
+            return [(None, 'skipped', recid)]
         
+        return examples
 
-  num_new = num_processed - num_skipped - num_existing
-  print(f"\r{shard_name}: {num_processed}/{shard_size} {num_new} new {num_skipped} bad            ")
 
-def create(
+def _process_file_shard_parallel_mp(
     tce_table: pd.DataFrame,
-    output_dir: str,
-    num_shards: int,
-    num_processes: int,
-    mode: AstronetMode,
+    file_name: str,
+    get_lightcurve,
+    mode,
     training: bool,
-    get_lightcurve: LCGetter,
+    output_dir: str, 
+    num_processes: int = None,
 ):
-    tf.io.gfile.makedirs(output_dir)
-    logging.info(f"Processing {len(tce_table)} TCEs")
+    shard_name = os.path.basename(file_name)
+    shard_size = len(tce_table)
+    num_processes = num_processes or 1
 
-    tce_shards: tuple[pd.DataFrame, str] = []  # List of (tce_table_shard, file_name)
-    boundaries = np.linspace(0, len(tce_table), num_shards + 1).astype(np.int)
-    for i in range(num_shards):
-        start, end = boundaries[i : i + 2]
-        tce_shards.append(
-            (start, end, os.path.join(output_dir, f"{i:05d}-of-{num_shards:05f}"))
-        )
-    logging.info(f"Processing {len(tce_table)} TCEs in {len(tce_shards)} shards.")
+    # Read existing TFRecords
+    existing = {}
+    try:
+        tfr = tf.data.TFRecordDataset(file_name)
+        for record in tfr:
+            ex_str = record.numpy()
+            ex = tf.train.Example.FromString(ex_str)
+            astro_id = ex.features.feature['astro_id'].int64_list.value[0]
+            existing[astro_id] = ex_str
+    except Exception as e:
+        logging.info(f"Warning: could not read existing records from {file_name}: {e}")
+    tce_dicts = tce_table.to_dict(orient='records')
+    logging.info(f"[{shard_name}] Starting processing with {num_processes} processes on {len(tce_dicts)} TCEs")
 
-    if num_processes == 1:
-        for start, end, file in tce_shards:
-            _process_file_shard(
-                tce_table[start:end],
-                file,
-                get_lightcurve,
-                mode,
-                training
-            )
-    else:
-        with multiprocessing.Pool(num_processes) as pool:
-            pool.starmap(
-                _process_file_shard,
-                [
-                    (
-                        tce_table[start:end],
-                        file,
-                        get_lightcurve,
-                        mode,
-                        training,
-                    )
-                    for start, end, file in tce_shards
-                ],
-            )
-    logging.info("Finished processing")
+    worker = ProcessRecordWorker(existing, get_lightcurve, mode, training, _process_tce, tce_table, output_dir, 5)
 
+    with multiprocessing.Pool(processes=num_processes) as pool:
+        results_nested  = pool.map(worker, tce_dicts)
+
+    results = [item for sublist in results_nested for item in sublist]  # Flatten
+
+
+    serialized = []
+    stats = {"new": 0, "reused": 0, "augmented": 0, "skipped": 0}
+
+    for ex_bytes, status, recid in results:
+        logging.info(f"[{shard_name}] Processed Astro ID {recid} -> {status}")
+        if ex_bytes:
+            serialized.append(ex_bytes)
+        stats[status] += 1
+
+    with tf.io.TFRecordWriter(file_name) as writer:
+        for ex in serialized:
+            writer.write(ex)
+
+    logging.info(f"[{shard_name}] Done. Total: {shard_size}, Stats: {stats}")
 
 def main(_):
     tf.io.gfile.makedirs(FLAGS.output_dir)
 
+    global tce_table
     tce_table = pd.read_csv(FLAGS.input_tce_csv_file, header=0, low_memory=False)
-
-    def get_lightcurve(astro_id: int, aperture: Optional[str] = None) -> tuple[np.ndarray, np.ndarray]:
-        aperture_key_map = {
-            "s": "SAP_FLUX_SML",
-            "m": "SAP_FLUX_MID",
-            "l": "SAP_FLUX_LAG",
-            None: "SAP_FLUX",
-        }
-        matching_tces = tce_table[tce_table["Astro ID"] == astro_id] # tce_table.where(tce_table["Astro ID"] == astro_id)
-        try:
-            _, tce = next(matching_tces.iterrows())
-        except StopIteration as e:
-            raise ValueError(f"Astro ID not found: {astro_id}") from e
-        if "MinT" not in tce:
-            tce["MinT"] = -np.inf
-        if "MaxT" not in tce:
-            tce["MaxT"] = np.inf
-        return preprocess.read_and_process_light_curve(
-           FLAGS.tess_data_dir,
-           aperture_key_map[aperture],
-           tce.File,
-           tce.MinT,
-           tce.MaxT,
-        )
 
     num_tces = len(tce_table)
     logging.info("Read %d TCEs", num_tces)
@@ -414,7 +402,9 @@ def main(_):
 
     logging.info("Processing %d total file shards", len(file_shards))
     for start, end, file_shard in file_shards:
-        _process_file_shard(tce_table[start:end], file_shard, get_lightcurve, FLAGS.mode, not FLAGS.not_training)
+        logging.info(f'Starting shard {file_shard}')
+        logging.info(f'{FLAGS.output_dir}')
+        _process_file_shard_parallel_mp(tce_table[start:end], file_shard, get_lightcurve, FLAGS.mode, False, output_dir=FLAGS.output_dir, num_processes=35)
     logging.info("Finished processing %d total file shards", len(file_shards))
 
 

--- a/astronet/preprocess/generate_input_records.py
+++ b/astronet/preprocess/generate_input_records.py
@@ -187,7 +187,7 @@ def _process_tce(
   import time
   start_time = time.time()
   astro_id = tce['Astro ID']
-  logging.info(f'Starting to process {astro_id}')
+  logging.debug(f'Starting to process {astro_id}')
   tme, flux = get_lightcurve(tce['Astro ID'])
   if mode == 'vetting':
     apertures = {
@@ -262,7 +262,7 @@ def _process_tce(
   _set_float_feature(ex, 'n_points', [len(fold_num)])
 
   end_time = time.time()
-  logging.info(f'Finished processing {astro_id} in {end_time - start_time} seconds')
+  logging.debug(f'Finished processing {astro_id} in {end_time - start_time} seconds')
   return ex
 
 tce_table = None
@@ -275,7 +275,7 @@ def get_lightcurve(astro_id: int, aperture: Optional[str] = None):
         None: "SAP_FLUX",
     }
     global tce_table
-    matching_tces = tce_table[tce_table["Astro ID"] == astro_id] # tce_table.where(tce_table["Astro ID"] == astro_id)
+    matching_tces = tce_table[tce_table["Astro ID"] == astro_id]
     try:
         _, tce = next(matching_tces.iterrows())
     except StopIteration as e:
@@ -328,7 +328,7 @@ class ProcessRecordWorker:
         return examples
 
 
-def _process_file_shard_parallel_mp(
+def create(
     tce_table: pd.DataFrame,
     file_name: str,
     get_lightcurve,
@@ -351,7 +351,7 @@ def _process_file_shard_parallel_mp(
             astro_id = ex.features.feature['astro_id'].int64_list.value[0]
             existing[astro_id] = ex_str
     except Exception as e:
-        logging.info(f"Warning: could not read existing records from {file_name}: {e}")
+        logging.debug(f"Warning: could not read existing records from {file_name}: {e}")
     tce_dicts = tce_table.to_dict(orient='records')
     logging.info(f"[{shard_name}] Starting processing with {num_processes} processes on {len(tce_dicts)} TCEs")
 
@@ -367,7 +367,7 @@ def _process_file_shard_parallel_mp(
     stats = {"new": 0, "reused": 0, "augmented": 0, "skipped": 0}
 
     for ex_bytes, status, recid in results:
-        logging.info(f"[{shard_name}] Processed Astro ID {recid} -> {status}")
+        logging.debug(f"[{shard_name}] Processed Astro ID {recid} -> {status}")
         if ex_bytes:
             serialized.append(ex_bytes)
         stats[status] += 1
@@ -404,7 +404,7 @@ def main(_):
     for start, end, file_shard in file_shards:
         logging.info(f'Starting shard {file_shard}')
         logging.info(f'{FLAGS.output_dir}')
-        _process_file_shard_parallel_mp(tce_table[start:end], file_shard, get_lightcurve, FLAGS.mode, False, output_dir=FLAGS.output_dir, num_processes=35)
+        create(tce_table[start:end], file_shard, get_lightcurve, FLAGS.mode, False, output_dir=FLAGS.output_dir, num_processes=35)
     logging.info("Finished processing %d total file shards", len(file_shards))
 
 

--- a/gen_reports_from_tfrecords.py
+++ b/gen_reports_from_tfrecords.py
@@ -1,0 +1,126 @@
+"""Script for outputting a report for a given TFRecords set."""
+
+from absl import app, flags, logging
+import tensorflow as tf
+from glob import glob
+import os
+import matplotlib.pyplot as plt
+import numpy as np
+from multiprocessing import Pool, cpu_count
+
+
+flags.DEFINE_string("tfrecord_dir", None, "TFRecord dir location.", required=True)
+flags.DEFINE_string("output_dir", None, "Output dir location.", required=True)
+
+FLAGS = flags.FLAGS
+
+def extract_features_by_prefix(example, prefix):
+    return {
+        k: np.array(example.features.feature[k].float_list.value)
+        for k in example.features.feature
+        if k.startswith(prefix)
+    }
+
+def extract_scalar_features(example, keys):
+    data = {}
+    for key in keys:
+        val = example.features.feature.get(key)
+        if val and val.HasField('float_list'):
+            data[key] = val.float_list.value[0]
+        elif val and val.HasField('int64_list'):
+            data[key] = val.int64_list.value[0]
+    return data
+
+def plot_scalar_properties(example, output_path):
+    scalar_keys = [
+        'astro_id', 'Period', 'Duration', 'Transit_Depth', 'Tmag',
+        'star_mass', 'star_rad', 'star_rad_est',
+        'disp_p', 'disp_n', 'disp_e', 'disp_b', 'disp_u', 'disp_t', 'disp_j', 'n_folds', 'n_points'
+    ]
+    scalar_data = extract_scalar_features(example, scalar_keys)
+
+    # Format into aligned table text (grouped per line)
+    items = [f"{k:<14}: {v:<.5g}" if isinstance(v, float) else f"{k:<14}: {v}" for k, v in scalar_data.items()]
+    lines = []
+    per_line = 3
+    for i in range(0, len(items), per_line):
+        lines.append("    ".join(items[i:i + per_line]))
+    body_text = "\n".join(lines)
+
+    fig, ax = plt.subplots(figsize=(10, 2.5))
+    ax.axis("off")
+
+    astro_id = scalar_data.get("astro_id", "Unknown")
+    fig.suptitle(f"Astro ID {astro_id} – Properties", fontsize=14, y=0.95)
+
+    ax.text(
+        0.01, 0.85, body_text,
+        fontsize=11, family="monospace", va="top", ha="left",
+        bbox=dict(boxstyle="round", facecolor="#f8f8f8", edgecolor="gray", pad=0.6)
+    )
+    plt.tight_layout(rect=[0, 0, 1, 0.9])
+    plt.savefig(output_path, dpi=150)
+    plt.close()
+
+def plot_views(example, prefix, output_path, title_suffix=""):
+    views = extract_features_by_prefix(example, prefix)
+    if not views:
+        return
+
+    n = len(views)
+    n_cols = 2
+    n_rows = (n + 1) // n_cols
+    fig, axes = plt.subplots(n_rows, n_cols, figsize=(6.5 * n_cols, 2.5 * n_rows))
+    axes = axes.flatten()
+
+    for i, (k, v) in enumerate(sorted(views.items())):
+        axes[i].plot(v, linewidth=0.5)
+        axes[i].set_title(k)
+        axes[i].set_xlabel("Index")
+        axes[i].set_ylabel("Flux")
+
+    for j in range(i+1, len(axes)):
+        axes[j].axis("off")
+
+    astro_id = example.features.feature.get('astro_id', None)
+    astro_id_val = astro_id.int64_list.value[0] if astro_id else "Unknown"
+    fig.suptitle(f"Astro ID {astro_id_val} – {title_suffix}", fontsize=14, y=0.98)
+
+    plt.tight_layout(rect=[0, 0, 1, 0.95])
+    plt.savefig(output_path, dpi=150)
+    plt.close()
+
+def generate_split_report(example, output_dir):
+    astro_id = example.features.feature['astro_id'].int64_list.value[0]
+    prefix =  os.path.join(output_dir, str(astro_id)[:3])
+    os.makedirs(prefix, exist_ok=True)
+    prefix = os.path.join(prefix, str(astro_id))
+
+    plot_scalar_properties(example, f"{prefix}_props.png")
+    plot_views(example, "global_view", f"{prefix}_global.png", title_suffix="Global Views")
+    plot_views(example, "local_view", f"{prefix}_local.png", title_suffix="Local Views")
+    plot_views(example, "secondary_", f"{prefix}_secondary.png", title_suffix="Secondary Views")
+    plot_views(example, "sample_segments", f"{prefix}_segments.png", title_suffix="Sample Segments Views")
+
+def run_parallel_report_generation(examples, output_dir, num_processes=None):
+    num_processes = num_processes or cpu_count()
+    args = [(ex, output_dir) for ex in examples]
+
+    with Pool(num_processes) as pool:
+        pool.starmap(generate_split_report, args)
+
+def main(_):
+    tfrecord_files = glob(f"{FLAGS.tfrecord_dir}/*")
+    print(f'\nStarting to generate reports from {FLAGS.tfrecord_dir} with {len(tfrecord_files)} files...\n')
+    dataset = tf.data.TFRecordDataset(tfrecord_files)
+    examples = []
+    for i, raw_record in enumerate(dataset):
+        example = tf.train.Example()
+        example.ParseFromString(raw_record.numpy())
+        examples.append(example)
+        
+    run_parallel_report_generation(examples, output_dir=FLAGS.output_dir, num_processes=32)
+
+if __name__ == "__main__":
+  logging.set_verbosity(logging.INFO)
+  app.run(main)

--- a/gen_reports_from_tfrecords.py
+++ b/gen_reports_from_tfrecords.py
@@ -110,7 +110,10 @@ def run_parallel_report_generation(examples, output_dir, num_processes=None):
         pool.starmap(generate_split_report, args)
 
 def main(_):
-    tfrecord_files = glob(f"{FLAGS.tfrecord_dir}/*")
+    tfrecord_files = [
+        f for f in glob(f"{FLAGS.tfrecord_dir}/*")
+        if os.path.splitext(f)[1] == ''
+    ] # TFRecord files have no suffix
     print(f'\nStarting to generate reports from {FLAGS.tfrecord_dir} with {len(tfrecord_files)} files...\n')
     dataset = tf.data.TFRecordDataset(tfrecord_files)
     examples = []

--- a/gen_reports_from_tfrecords.sh
+++ b/gen_reports_from_tfrecords.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+TFRECORD_DIR=/pdo/astronet-data/data/tfrecords/sector-85
+OUTPUT_DIR=/pdo/astronet-data/data/tfrecord_reports/
+
+echo "Generating TFRecord Reports For $TFRECORD_DIR -- Saving to $OUTPUT_DIR"
+python astronet/gen_reports_from_tfrecords.py \
+    --tfrecord_dir="$TFRECORD_DIR" \
+    --output_dir="$OUTPUT_DIR"


### PR DESCRIPTION
Adds improved parallelization for TFRecord generation. Previously, we were using multithreading which had some limitations around CPU resourcing since we are pretty strictly IO bound. It is better to have separate processes to handle clusters of TIC ids. This has led in practice to a 10x improvement when used on sector 86 (40+ hours cut down to <4). I have verified that the inputs and outputs are exactly the same as previously. We are using the outputs of this code already for sector 86 analysis.

Also helps to streamline TFRecord generation for recent sectors, used for 85, 86, and 87. See https://docs.google.com/document/d/1cyJOZXTpax7HuILo87kVr1VSM-gNGc3pfxjDud_J_Ys/edit?tab=t.0#heading=h.m8tcjwxhfjqo for updated instructions. Mostly this includes a helper script, gen_tce_csv.py, which takes as input a sector number and provides as output a CSV file with all of the properties + FITS file paths which are to be used for TFRecord generation.